### PR TITLE
Speed up typing and dashboard interactions

### DIFF
--- a/extension.css
+++ b/extension.css
@@ -697,6 +697,8 @@ body.bt-theme-dark .bt-sidebar__close:hover {
     max-height: 100%;
     overflow: hidden;
     font-family: inherit;
+    container-name: bt-dashboard;
+    container-type: inline-size;
 }
 
 .bt-dashboard__header {
@@ -704,13 +706,15 @@ body.bt-theme-dark .bt-sidebar__close:hover {
     border-bottom: 1px solid var(--bt-border);
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    gap: 4px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 10px 12px;
 }
 
 .bt-dashboard__header > div:first-child {
-    flex: 1;
+    flex: 1 1 180px;
     min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .bt-dashboard__header--draggable {
@@ -730,18 +734,30 @@ body.bt-theme-dark .bt-sidebar__close:hover {
 .bt-dashboard__header h2 {
     margin: 0 0 4px;
     font-size: 18px;
+    line-height: 1.2;
+}
+
+.bt-dashboard__header p {
+    margin: 0;
+    line-height: 1.45;
+    max-width: 52ch;
+    overflow-wrap: anywhere;
 }
 
 .bt-dashboard__header-actions {
-    min-width: 175px !important;
+    min-width: 0 !important;
     display: flex;
     align-items: center;
     gap: 6px;
-    flex-wrap: nowrap;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    margin-left: auto;
 }
 
 .bt-dashboard__header-actions button {
-    margin-left: 4px;
+    margin: 0;
+    flex: 0 0 auto;
 }
 
 .bt-dashboard__header-actions .bp3-button {
@@ -752,6 +768,19 @@ body.bt-theme-dark .bt-sidebar__close:hover {
     color: var(--bt-panel-text);
     border: 1px solid var(--bt-border, var(--bt-border));
     box-shadow: none;
+}
+
+@container bt-dashboard (max-width: 700px) {
+    .bt-dashboard__header > div:first-child {
+        flex-basis: 100%;
+        width: 100%;
+    }
+
+    .bt-dashboard__header-actions {
+        width: 100%;
+        margin-left: 0;
+        justify-content: flex-start;
+    }
 }
 
 .bt-dashboard__quick-add {

--- a/extension.css
+++ b/extension.css
@@ -5536,16 +5536,22 @@ body.bt-theme-dark .bt-activity-item__source {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-width: 16px;
+    width: 22px;
+    min-width: 22px;
     height: 16px;
     margin-left: 6px;
-    padding: 0 4px;
+    padding: 0 2px;
     border-radius: 8px;
     background: var(--bt-chart-bar, #4a90d9);
     color: #fff;
     font-size: 10px;
     font-weight: 700;
+    font-variant-numeric: tabular-nums;
     line-height: 1;
+}
+
+.bt-suggestions-badge--placeholder {
+    visibility: hidden;
 }
 
 @media (max-width: 640px) {

--- a/src/core/analytics-cache.js
+++ b/src/core/analytics-cache.js
@@ -1,0 +1,37 @@
+export const DEFAULT_ANALYTICS_PERIODS = ["30d", "7d", "90d", "all"];
+
+export function createAnalyticsCache() {
+  const values = new Map();
+
+  return {
+    get(period) {
+      return values.get(period) || null;
+    },
+    has(period) {
+      return values.has(period);
+    },
+    set(period, data) {
+      values.set(period, data);
+      return data;
+    },
+    clear() {
+      values.clear();
+    },
+    async warm({
+      periods = DEFAULT_ANALYTICS_PERIODS,
+      compute,
+      yieldToMainThread = null,
+      isCancelled = null,
+    } = {}) {
+      if (typeof compute !== "function") return;
+      for (const period of periods) {
+        if (isCancelled?.()) return;
+        if (values.has(period)) continue;
+        if (typeof yieldToMainThread === "function") await yieldToMainThread();
+        if (isCancelled?.()) return;
+        const data = await compute(period);
+        if (data != null && !values.has(period)) values.set(period, data);
+      }
+    },
+  };
+}

--- a/src/core/attribute-edit.js
+++ b/src/core/attribute-edit.js
@@ -18,6 +18,9 @@ export function parseAttributeEditTarget(target) {
   }
 
   if (typeof rawText !== "string") return null;
+  // Ordinary prose is overwhelmingly the common case. Avoid even the Unicode
+  // attribute regex unless the draft contains Roam's attribute delimiter.
+  if (!rawText.includes("::")) return null;
   const match = rawText.trim().match(ATTRIBUTE_LINE_RE);
   if (!match) return null;
 
@@ -26,4 +29,3 @@ export function parseAttributeEditTarget(target) {
     value: match[2],
   };
 }
-

--- a/src/core/attribute-edit.js
+++ b/src/core/attribute-edit.js
@@ -1,0 +1,29 @@
+const ATTRIBUTE_LINE_RE = /^([\p{L}\p{N}_\-\/\s]+)::\s*(.+)$/u;
+
+/**
+ * Read the current draft without touching Roam's graph API.
+ *
+ * Better Tasks listens at document scope so it can mirror child attributes
+ * into task props. Almost every input event is unrelated, though. Keeping
+ * this check pure and synchronous lets normal block typing leave immediately.
+ */
+export function parseAttributeEditTarget(target) {
+  if (!target || typeof target !== "object") return null;
+
+  let rawText = null;
+  if (typeof target.value === "string") {
+    rawText = target.value;
+  } else if (target.isContentEditable && typeof target.textContent === "string") {
+    rawText = target.textContent;
+  }
+
+  if (typeof rawText !== "string") return null;
+  const match = rawText.trim().match(ATTRIBUTE_LINE_RE);
+  if (!match) return null;
+
+  return {
+    key: match[1].trim().toLowerCase(),
+    value: match[2],
+  };
+}
+

--- a/src/core/block-references.js
+++ b/src/core/block-references.js
@@ -1,0 +1,43 @@
+export const BLOCK_REFERENCE_RE = /\(\(([A-Za-z0-9_-]{9})\)\)/g;
+
+export function extractBlockReferenceUids(value) {
+  const input = String(value ?? "");
+  const seen = new Set();
+  const out = [];
+  BLOCK_REFERENCE_RE.lastIndex = 0;
+  let match;
+  while ((match = BLOCK_REFERENCE_RE.exec(input)) !== null) {
+    if (!seen.has(match[1])) {
+      seen.add(match[1]);
+      out.push(match[1]);
+    }
+  }
+  return out;
+}
+
+export function resolveBlockReferences(value, resolver, options = {}) {
+  const input = String(value ?? "");
+  if (!input || typeof resolver !== "function") return input;
+  const maxDepth = Number.isInteger(options.maxDepth) ? Math.max(0, options.maxDepth) : 4;
+  const seen = options.seen instanceof Set ? options.seen : new Set();
+
+  const visit = (text, depth, active) => {
+    if (depth > maxDepth) return text;
+    return String(text).replace(BLOCK_REFERENCE_RE, (raw, uid) => {
+      if (active.has(uid)) return raw;
+      let resolved = null;
+      try {
+        resolved = resolver(uid);
+      } catch (_) {
+        resolved = null;
+      }
+      if (typeof resolved !== "string" || !resolved.trim()) return raw;
+      if (depth === maxDepth) return resolved.trim();
+      const nextActive = new Set(active);
+      nextActive.add(uid);
+      return visit(resolved.trim(), depth + 1, nextActive);
+    });
+  };
+
+  return visit(input, 0, seen);
+}

--- a/src/core/dashboard-warmup.js
+++ b/src/core/dashboard-warmup.js
@@ -1,0 +1,44 @@
+/**
+ * Warm the dashboard model after Roam reaches an idle slice.
+ *
+ * This keeps the extension's startup path light while removing the graph-wide
+ * task collection from the first dashboard click. The returned disposer is
+ * safe to call whether the callback has fired or not.
+ */
+export function scheduleDashboardWarmup(
+  controller,
+  { windowLike = globalThis.window, timeoutMs = 4000 } = {}
+) {
+  if (!controller || typeof controller.ensureInitialLoad !== "function") return () => {};
+
+  let disposed = false;
+  let idleId = null;
+  let timerId = null;
+  const run = () => {
+    idleId = null;
+    timerId = null;
+    if (disposed || controller.isOpen?.()) return;
+    try {
+      const result = controller.ensureInitialLoad();
+      result?.catch?.((error) => {
+        console.warn("[BetterTasks] dashboard warm-up failed", error);
+      });
+    } catch (error) {
+      console.warn("[BetterTasks] dashboard warm-up failed", error);
+    }
+  };
+
+  if (typeof windowLike?.requestIdleCallback === "function") {
+    idleId = windowLike.requestIdleCallback(run, { timeout: timeoutMs });
+  } else {
+    timerId = windowLike?.setTimeout?.(run, Math.min(timeoutMs, 1500));
+  }
+
+  return () => {
+    disposed = true;
+    if (idleId != null) windowLike?.cancelIdleCallback?.(idleId);
+    if (timerId != null) windowLike?.clearTimeout?.(timerId);
+    idleId = null;
+    timerId = null;
+  };
+}

--- a/src/core/dashboard-warmup.js
+++ b/src/core/dashboard-warmup.js
@@ -14,14 +14,34 @@ export function scheduleDashboardWarmup(
   let disposed = false;
   let idleId = null;
   let timerId = null;
-  const run = () => {
+  const pendingIdleWaits = new Map();
+  const waitForIdle = () => new Promise((resolve) => {
+    if (disposed) {
+      resolve();
+      return;
+    }
+    const finish = (id) => {
+      pendingIdleWaits.delete(id);
+      resolve();
+    };
+    if (typeof windowLike?.requestIdleCallback === "function") {
+      const id = windowLike.requestIdleCallback(() => finish(id), { timeout: timeoutMs });
+      pendingIdleWaits.set(id, { kind: "idle", resolve });
+    } else {
+      const id = windowLike?.setTimeout?.(() => finish(id), 0);
+      pendingIdleWaits.set(id, { kind: "timer", resolve });
+    }
+  });
+  const run = async () => {
     idleId = null;
     timerId = null;
     if (disposed || controller.isOpen?.()) return;
     try {
-      const result = controller.ensureInitialLoad();
-      result?.catch?.((error) => {
-        console.warn("[BetterTasks] dashboard warm-up failed", error);
+      await controller.ensureInitialLoad();
+      if (disposed || controller.isOpen?.()) return;
+      await controller.warmAnalyticsCache?.({
+        yieldToMainThread: waitForIdle,
+        isCancelled: () => disposed || !!controller.isOpen?.(),
       });
     } catch (error) {
       console.warn("[BetterTasks] dashboard warm-up failed", error);
@@ -38,6 +58,12 @@ export function scheduleDashboardWarmup(
     disposed = true;
     if (idleId != null) windowLike?.cancelIdleCallback?.(idleId);
     if (timerId != null) windowLike?.clearTimeout?.(timerId);
+    for (const [id, entry] of pendingIdleWaits) {
+      if (entry.kind === "idle") windowLike?.cancelIdleCallback?.(id);
+      else windowLike?.clearTimeout?.(id);
+      entry.resolve();
+    }
+    pendingIdleWaits.clear();
     idleId = null;
     timerId = null;
   };

--- a/src/core/direct-parent.js
+++ b/src/core/direct-parent.js
@@ -1,0 +1,15 @@
+/**
+ * Build a query for a block's immediate parent.
+ *
+ * `:block/parents` contains every ancestor and does not guarantee an order,
+ * so taking its first result can select the page or a higher container. The
+ * inverse `:block/children` relation identifies the direct parent exactly.
+ */
+export function buildDirectParentUidQuery(safeChildUid) {
+  return `
+        [:find ?puid
+         :where
+         [?c :block/uid "${safeChildUid}"]
+         [?p :block/children ?c]
+         [?p :block/uid ?puid]]`;
+}

--- a/src/core/filters.js
+++ b/src/core/filters.js
@@ -152,7 +152,7 @@ export function applyFilters(tasks, filters, query = "", options = {}) {
       if (!matches) return false;
     }
     if (queryText) {
-      const haystack = `${task.title} ${task.pageTitle || ""} ${task.text}`.toLowerCase();
+      const haystack = `${task.displayTitle || ""} ${task.title} ${task.pageTitle || ""} ${task.text}`.toLowerCase();
       if (!haystack.includes(queryText)) return false;
     }
     return true;

--- a/src/core/open-settings.js
+++ b/src/core/open-settings.js
@@ -1,0 +1,70 @@
+const SETTINGS_TAB_SELECTOR = '[role="tab"]';
+const DEPOT_BUTTON_SELECTOR = ".rm-left-sidebar__roam-depot";
+
+function normalizedText(node) {
+  return String(node?.textContent || node?.innerText || "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Find the settings tab Roam creates for Better Tasks.
+ *
+ * Developer extensions are displayed as "Better Tasks (dev)" even though
+ * the registered tabTitle is still "Better Tasks", so prefer that exact tab
+ * when both the Depot and developer builds are present.
+ */
+export function findBetterTasksSettingsTab(documentLike) {
+  const tabs = Array.from(documentLike?.querySelectorAll?.(SETTINGS_TAB_SELECTOR) || []);
+  const exactDev = tabs.find((tab) => normalizedText(tab) === "Better Tasks (dev)");
+  if (exactDev) return exactDev;
+  const exactRelease = tabs.find((tab) => normalizedText(tab) === "Better Tasks");
+  if (exactRelease) return exactRelease;
+  return tabs.find((tab) => /^Better Tasks(?:\s|\(|$)/i.test(normalizedText(tab))) || null;
+}
+
+export function selectBetterTasksSettingsTab(documentLike) {
+  const tab = findBetterTasksSettingsTab(documentLike);
+  if (!tab || typeof tab.click !== "function") return false;
+  tab.click();
+  return true;
+}
+
+const defaultWait = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
+
+/**
+ * Open Roam Depot and focus Better Tasks' extension settings.
+ *
+ * Roam's documented extension settings API can create a panel, but currently
+ * has no method for opening it. This small DOM adapter is intentionally kept
+ * isolated so it can be removed when Roam exposes an official opener.
+ */
+export async function openBetterTasksSettings({
+  documentLike = typeof document !== "undefined" ? document : null,
+  roamAlphaAPI = typeof window !== "undefined" ? window.roamAlphaAPI : null,
+  wait = defaultWait,
+  attempts = 24,
+  intervalMs = 50,
+} = {}) {
+  if (!documentLike) return false;
+  if (selectBetterTasksSettingsTab(documentLike)) return true;
+
+  let depotButton = documentLike.querySelector?.(DEPOT_BUTTON_SELECTOR) || null;
+  if (!depotButton) {
+    try {
+      await roamAlphaAPI?.ui?.leftSidebar?.open?.();
+    } catch (_) {
+      // The settings dialog can still be opened if the sidebar is already in
+      // the DOM; continue to the normal lookup below.
+    }
+    depotButton = documentLike.querySelector?.(DEPOT_BUTTON_SELECTOR) || null;
+  }
+  if (!depotButton || typeof depotButton.click !== "function") return false;
+  depotButton.click();
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (selectBetterTasksSettingsTab(documentLike)) return true;
+    await wait(intervalMs);
+  }
+  return false;
+}

--- a/src/core/suggestion-snapshot.js
+++ b/src/core/suggestion-snapshot.js
@@ -1,0 +1,46 @@
+export const SUGGESTION_COUNT_SNAPSHOT_SCHEMA = 1;
+export const SUGGESTION_COUNT_SNAPSHOT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function suggestionCountSnapshotKey(graphName = "default") {
+  return `betterTasks.dashboard.suggestionCount.${encodeURIComponent(String(graphName || "default"))}`;
+}
+
+export function readSuggestionCountSnapshot(
+  storage,
+  key,
+  { now = Date.now(), maxAgeMs = SUGGESTION_COUNT_SNAPSHOT_MAX_AGE_MS } = {}
+) {
+  if (!storage || !key) return null;
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const count = Number(parsed?.count);
+    const computedAt = Number(parsed?.computedAt);
+    if (parsed?.schema !== SUGGESTION_COUNT_SNAPSHOT_SCHEMA) return null;
+    if (!Number.isInteger(count) || count < 0 || count > 10000) return null;
+    if (!Number.isFinite(computedAt) || computedAt <= 0) return null;
+    if (now - computedAt > maxAgeMs || computedAt - now > 60 * 1000) return null;
+    return { count, computedAt };
+  } catch (_) {
+    return null;
+  }
+}
+
+export function writeSuggestionCountSnapshot(storage, key, count, { now = Date.now() } = {}) {
+  const normalized = Number(count);
+  if (!storage || !key || !Number.isInteger(normalized) || normalized < 0 || normalized > 10000) {
+    return null;
+  }
+  const snapshot = {
+    schema: SUGGESTION_COUNT_SNAPSHOT_SCHEMA,
+    count: normalized,
+    computedAt: now,
+  };
+  try {
+    storage.setItem(key, JSON.stringify(snapshot));
+    return snapshot;
+  } catch (_) {
+    return null;
+  }
+}

--- a/src/core/theme-observer.js
+++ b/src/core/theme-observer.js
@@ -1,0 +1,31 @@
+/**
+ * Better Tasks resamples its panel colors whenever `document.body` /
+ * `document.documentElement` gain or lose a theme-indicating class
+ * (`bp3-dark`) or `data-theme` attribute — see syncDashboardThemeVars,
+ * which only ever reads `body.classList` / `root.classList` themselves.
+ * It never inspects a descendant's class list, and the Roam Studio /
+ * Blueprint toggle buttons already get their own narrowly-scoped
+ * observers and click listener.
+ *
+ * `subtree: true` on body/documentElement therefore buys nothing: it
+ * just means every class/data-theme mutation ANYWHERE inside Roam's
+ * whole UI queues a MutationRecord for us. Roam mutates classes
+ * constantly while typing (decorations, focus/caret state, virtualized
+ * rows), so that bookkeeping is charged to Roam's own render task on
+ * nearly every keystroke — a graph-wide latency tax invisible as this
+ * extension's own CPU time. `document.head` keeps subtree tracking:
+ * theme extensions swap `<link>`/`<style>` tags there, and head almost
+ * never mutates while a user is just typing.
+ */
+export function getThemeObserverRegistrations({ body, documentElement, head } = {}) {
+  const registrations = [];
+  for (const target of [body, documentElement, head]) {
+    if (!target) continue;
+    const options =
+      target === head
+        ? { childList: true, subtree: true, attributes: true, attributeFilter: ["href", "data-theme"] }
+        : { attributes: true, attributeFilter: ["class", "data-theme"], subtree: false };
+    registrations.push({ target, options });
+  }
+  return registrations;
+}

--- a/src/dashboard/App.jsx
+++ b/src/dashboard/App.jsx
@@ -1529,8 +1529,8 @@ function TaskRow({ task, controller, strings, selectionActive, isSelected, onTog
 
 function AnalyticsPanel({ controller, language, onClose }) {
   const [period, setPeriod] = useState("30d");
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState(() => controller?.getAnalyticsCached?.("30d") || null);
+  const [loading, setLoading] = useState(() => !controller?.getAnalyticsCached?.("30d"));
   const panelRef = useRef(null);
   const lang = language || "en";
   const s = (key, fallback) => tPath(["analytics", key], lang) ?? fallback;
@@ -1547,6 +1547,12 @@ function AnalyticsPanel({ controller, language, onClose }) {
 
   useEffect(() => {
     let cancelled = false;
+    const cached = controller?.getAnalyticsCached?.(period);
+    if (cached) {
+      setData(cached);
+      setLoading(false);
+      return () => { cancelled = true; };
+    }
     setLoading(true);
     controller?.computeAnalytics?.(period).then((result) => {
       if (!cancelled) { setData(result); setLoading(false); }
@@ -1644,7 +1650,12 @@ function AnalyticsPanel({ controller, language, onClose }) {
               key={p.key}
               type="button"
               className={`bt-analytics-period-btn${period === p.key ? " bt-analytics-period-btn--active" : ""}`}
-              onClick={() => setPeriod(p.key)}
+              onClick={() => {
+                const cached = controller?.getAnalyticsCached?.(p.key);
+                setData(cached || null);
+                setLoading(!cached);
+                setPeriod(p.key);
+              }}
             >
               {p.label}
             </button>
@@ -3707,6 +3718,19 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
     revalidate().catch(() => {});
     return () => { cancelled = true; };
   }, [controller, suggestionsEnabled, snapshot?.status]);
+  // Analytics is derived entirely from the dashboard model. Fill all period
+  // caches one idle slice at a time, pausing whenever the user scrolls, so the
+  // first open and every period switch are paint-only interactions.
+  useEffect(() => {
+    if (snapshot?.status !== "ready") return undefined;
+    let cancelled = false;
+    const gate = scrollIdleGateRef.current;
+    controller?.warmAnalyticsCache?.({
+      yieldToMainThread: () => gate?.wait?.() || Promise.resolve(),
+      isCancelled: () => cancelled,
+    })?.catch?.(() => {});
+    return () => { cancelled = true; };
+  }, [controller, snapshot?.status, snapshot?.lastUpdated]);
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
     const mq = window.matchMedia("(max-width: 639px)");

--- a/src/dashboard/App.jsx
+++ b/src/dashboard/App.jsx
@@ -12,6 +12,7 @@ import iziToast from "izitoast";
 import { useVirtualizer, measureElement } from "@tanstack/react-virtual";
 import { applyFilters } from "../core/filters";
 import { i18n as I18N_MAP } from "../i18n";
+import { estimateDashboardRowSize } from "./rowEstimate";
 import {
   createView,
   updateView,
@@ -3672,14 +3673,17 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [isMobileLayout, sidebarOpen]);
+  const estimatedViewportWidth = useMemo(() => {
+    if (typeof window === "undefined") return 620;
+    if (snapshot?.isFullPage || isMobileLayout) return Math.max(320, window.innerWidth - 96);
+    return 620;
+  }, [snapshot?.isFullPage, isMobileLayout]);
   const estimateRowSize = useCallback(
-    (index) => {
-      const row = rows[index];
-      if (row?.type === "group") return 40;
-      if (row?.type === "subtask") return 80;
-      return 100;
-    },
-    [rows]
+    (index) => estimateDashboardRowSize(rows[index], {
+      viewportWidth: estimatedViewportWidth,
+      mobile: isMobileLayout,
+    }),
+    [rows, estimatedViewportWidth, isMobileLayout]
   );
   const getRowKey = useCallback((index) => rows[index]?.key ?? index, [rows]);
   const getScrollElement = useCallback(() => parentRef.current, []);
@@ -3689,8 +3693,14 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
       estimateSize: estimateRowSize,
       getItemKey: getRowKey,
       getScrollElement,
-      overscan: isMobileApp ? 4 : isTouchDevice ? 6 : 8,
+      // The viewport usually shows only 2–4 rich task rows. Four rows of
+      // desktop overscan avoids blank edges without mounting ~20 button-heavy
+      // rows on every scroll step.
+      overscan: isMobileApp ? 3 : isTouchDevice ? 4 : 4,
       measureElement,
+      // Coalesce ResizeObserver corrections with paint instead of forcing
+      // several independent layout updates during the same scroll frame.
+      useAnimationFrameWithResizeObserver: true,
     }),
     [rows.length, estimateRowSize, getRowKey, getScrollElement, isMobileApp, isTouchDevice]
   );

--- a/src/dashboard/App.jsx
+++ b/src/dashboard/App.jsx
@@ -11,8 +11,10 @@ import { createPortal } from "react-dom";
 import iziToast from "izitoast";
 import { useVirtualizer, measureElement } from "@tanstack/react-virtual";
 import { applyFilters } from "../core/filters";
+import { resolveBlockReferences } from "../core/block-references";
 import { i18n as I18N_MAP } from "../i18n";
-import { estimateDashboardRowSize } from "./rowEstimate";
+import { estimateDashboardRowSize, visibleDashboardText } from "./rowEstimate";
+import { createScrollIdleGate } from "./scrollIdleGate";
 import { shouldAdjustDashboardScrollPositionOnItemSizeChange } from "./scrollStability";
 import {
   createView,
@@ -182,9 +184,12 @@ function cycleGtdStatus(current) {
   return order[(idx + 1) % order.length];
 }
 
-const TITLE_TOKEN_RE = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)|\[\[([^\]]+)\]\]/g;
+const TITLE_TOKEN_RE = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)|\[\[([^\]]+)\]\]|\(\(([A-Za-z0-9_-]{9})\)\)/g;
 
-function resolvePageUid(title) {
+function resolvePageUid(title, controller) {
+  if (typeof controller?.resolvePageUid === "function") {
+    return controller.resolvePageUid(title);
+  }
   try {
     const result = window.roamAlphaAPI?.data?.pull?.(
       "[:block/uid]", [":node/title", title]
@@ -219,7 +224,7 @@ function renderTitleWithLinks(title, controller) {
     } else if (match[3]) {
       // Page ref: [[page name]]
       const pageName = match[3];
-      const pageUid = resolvePageUid(pageName);
+      const pageUid = resolvePageUid(pageName, controller);
       if (pageUid && controller?.openPage) {
         parts.push(
           <button
@@ -234,6 +239,30 @@ function renderTitleWithLinks(title, controller) {
         );
       } else {
         parts.push(<span key={`pr-${match.index}`} className="bt-task-row__page-ref--plain">{pageName}</span>);
+      }
+    } else if (match[4]) {
+      // Block ref: display the referenced block text while keeping the whole
+      // resolved label as one navigation target (nested buttons are invalid).
+      const blockUid = match[4];
+      const resolved = controller?.resolveBlockRefTitle?.(blockUid);
+      const fullyResolved = resolved
+        ? resolveBlockReferences(resolved, (uid) => controller?.resolveBlockRefTitle?.(uid))
+        : null;
+      const label = fullyResolved ? visibleDashboardText(fullyResolved) : match[0];
+      if (resolved && controller?.openBlock) {
+        parts.push(
+          <button
+            key={`br-${match.index}`}
+            type="button"
+            className="bt-task-row__page-ref bt-task-row__block-ref"
+            onClick={(e) => { e.stopPropagation(); controller.openBlock(blockUid); }}
+            title="Open referenced block"
+          >
+            {label}
+          </button>
+        );
+      } else {
+        parts.push(<span key={`br-${match.index}`} className="bt-task-row__page-ref--plain">{label}</span>);
       }
     }
     lastIndex = TITLE_TOKEN_RE.lastIndex;
@@ -1854,8 +1883,9 @@ const SUGGESTION_RULE_TEXT_KEYS = {
 };
 
 function SuggestionsPanel({ controller, language, onClose, onCountChange }) {
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const initialCached = controller?.getSuggestionsCached?.() || null;
+  const [data, setData] = useState(initialCached);
+  const [loading, setLoading] = useState(!initialCached);
   const [pendingId, setPendingId] = useState(null);
   const panelRef = useRef(null);
   const lang = language || "en";
@@ -1865,7 +1895,7 @@ function SuggestionsPanel({ controller, language, onClose, onCountChange }) {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
+    setLoading(!controller?.getSuggestionsCached?.());
     controller?.computeSuggestions?.()
       .then((result) => {
         if (cancelled) return;
@@ -3131,6 +3161,18 @@ function EmptyState({ status, onRefresh, strings }) {
   return <div className="bt-empty">{copy.noMatch || "No tasks match the selected filters."}</div>;
 }
 
+function SuggestionsBadge({ count }) {
+  const visible = Number.isInteger(count) && count > 0;
+  return (
+    <span
+      className={`bt-suggestions-badge${visible ? "" : " bt-suggestions-badge--placeholder"}`}
+      aria-hidden={!visible}
+    >
+      {visible ? count : 0}
+    </span>
+  );
+}
+
 export default function DashboardApp({ controller, onRequestClose, onHeaderReady, language = "en" }) {
   const snapshot = useControllerSnapshot(controller);
   const [filters, dispatchFilters] = useReducer(filtersReducer, DEFAULT_FILTERS, loadSavedFilters);
@@ -3198,7 +3240,9 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
   const [showAnalytics, setShowAnalytics] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [suggestionsCount, setSuggestionsCount] = useState(
-    () => controller?.getSuggestionsCached?.()?.suggestions?.length ?? null
+    () => controller?.getSuggestionsCountCached?.()
+      ?? controller?.getSuggestionsCached?.()?.suggestions?.length
+      ?? null
   );
   const handleSuggestionsCount = useCallback((n) => setSuggestionsCount(n), []);
   // Read once per controller — toggling the setting takes effect when the
@@ -3207,21 +3251,6 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
     () => controller?.getSuggestionSettings?.()?.enabled !== false,
     [controller]
   );
-  // Warm the badge shortly after the dashboard opens: suggestions otherwise
-  // compute only on panel open, which left the badge empty after a Roam
-  // reload. Deferred so it never competes with the initial task load.
-  const suggestionsWarmupRan = useRef(false);
-  useEffect(() => {
-    if (!suggestionsEnabled || suggestionsWarmupRan.current) return undefined;
-    if (controller?.getSuggestionsCached?.()) return undefined; // already warm
-    suggestionsWarmupRan.current = true;
-    const timer = setTimeout(() => {
-      controller?.computeSuggestions?.()
-        .then((result) => setSuggestionsCount(result?.suggestions?.length ?? 0))
-        .catch(() => {});
-    }, 2500);
-    return () => clearTimeout(timer);
-  }, [controller, suggestionsEnabled]);
   const [focusModeOpen, setFocusModeOpen] = useState(false);
   const [focusQueue, setFocusQueue] = useState(null);
 
@@ -3625,6 +3654,59 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
 
   const rows = useVirtualRows(groups, expandedGroups, expandedParentTasks, filteredTaskIndex);
   const parentRef = useRef(null);
+  const scrollIdleGateRef = useRef(null);
+  if (!scrollIdleGateRef.current) {
+    scrollIdleGateRef.current = createScrollIdleGate();
+  }
+  useEffect(() => {
+    const node = parentRef.current;
+    const gate = scrollIdleGateRef.current;
+    if (!node || !gate) return undefined;
+    const onScroll = () => gate.markScroll();
+    const onScrollEnd = () => gate.markScrollEnd();
+    node.addEventListener("scroll", onScroll, { passive: true });
+    node.addEventListener("scrollend", onScrollEnd, { passive: true });
+    return () => {
+      node.removeEventListener("scroll", onScroll);
+      node.removeEventListener("scrollend", onScrollEnd);
+    };
+  }, [snapshot?.status, snapshot?.isFullPage, isMobileLayout]);
+  useEffect(() => () => scrollIdleGateRef.current?.dispose?.(), []);
+  // Keep the Suggestions indication proactive without putting its graph reads
+  // or React state update on the scroll path. The last verified count paints
+  // immediately. On a browser's first run, a zero-I/O model pass supplies a
+  // provisional count, then the complete analysis revalidates automatically in
+  // tiny idle chunks. The final badge update itself also waits for scroll quiet.
+  useEffect(() => {
+    if (!suggestionsEnabled || snapshot?.status !== "ready") return undefined;
+    let cancelled = false;
+    const gate = scrollIdleGateRef.current;
+    const revalidate = async () => {
+      if (suggestionsCount == null) {
+        const provisional = await controller?.computeSuggestions?.({ fast: true });
+        await (gate?.wait?.() || Promise.resolve());
+        if (!cancelled) {
+          setSuggestionsCount((previous) => {
+            const next = provisional?.suggestions?.length ?? 0;
+            return previous === next ? previous : next;
+          });
+        }
+      }
+      const verified = await controller?.computeSuggestions?.({
+        background: true,
+        yieldToMainThread: () => gate?.wait?.() || Promise.resolve(),
+      });
+      await (gate?.wait?.() || Promise.resolve());
+      if (!cancelled) {
+        setSuggestionsCount((previous) => {
+          const next = verified?.suggestions?.length ?? 0;
+          return previous === next ? previous : next;
+        });
+      }
+    };
+    revalidate().catch(() => {});
+    return () => { cancelled = true; };
+  }, [controller, suggestionsEnabled, snapshot?.status]);
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
     const mq = window.matchMedia("(max-width: 639px)");
@@ -5101,9 +5183,7 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
                 onClick={() => setShowSuggestions(true)}
               >
                 {tPath(["suggestions", "title"], lang) || "Suggestions"}
-                {suggestionsCount > 0 ? (
-                  <span className="bt-suggestions-badge">{suggestionsCount}</span>
-                ) : null}
+                <SuggestionsBadge count={suggestionsCount} />
               </button>
             ) : null}
             {!isMobileLayout ? (
@@ -5548,9 +5628,7 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
               onClick={() => setShowSuggestions(true)}
             >
               {tPath(["suggestions", "title"], lang) || "Suggestions"}
-              {suggestionsCount > 0 ? (
-                <span className="bt-suggestions-badge">{suggestionsCount}</span>
-              ) : null}
+              <SuggestionsBadge count={suggestionsCount} />
             </button>
           ) : null}
           {!isMobileLayout ? (

--- a/src/dashboard/App.jsx
+++ b/src/dashboard/App.jsx
@@ -13,6 +13,7 @@ import { useVirtualizer, measureElement } from "@tanstack/react-virtual";
 import { applyFilters } from "../core/filters";
 import { i18n as I18N_MAP } from "../i18n";
 import { estimateDashboardRowSize } from "./rowEstimate";
+import { shouldAdjustDashboardScrollPositionOnItemSizeChange } from "./scrollStability";
 import {
   createView,
   updateView,
@@ -3698,6 +3699,14 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
       // rows on every scroll step.
       overscan: isMobileApp ? 3 : isTouchDevice ? 4 : 4,
       measureElement,
+      // Never rewrite scrollTop after a late row measurement. The estimates
+      // are tuned to the rendered cards, and preserving the user's physical
+      // trackpad position prevents the post-scroll anchor nudge.
+      shouldAdjustScrollPositionOnItemSizeChange:
+        shouldAdjustDashboardScrollPositionOnItemSizeChange,
+      // Prefer the browser's true momentum-scroll boundary. TanStack falls
+      // back to its debounce automatically on browsers without scrollend.
+      useScrollendEvent: true,
       // Coalesce ResizeObserver corrections with paint instead of forcing
       // several independent layout updates during the same scroll frame.
       useAnimationFrameWithResizeObserver: true,
@@ -5108,6 +5117,15 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
             <button
               type="button"
               className="bp3-button bp3-small"
+              onClick={() => controller?.openSettings?.()}
+              aria-label="Settings"
+              title="Open Better Tasks settings"
+            >
+              Settings
+            </button>
+            <button
+              type="button"
+              className="bp3-button bp3-small"
               onClick={onRequestClose}
               aria-label={ui.close}
             >
@@ -5542,6 +5560,15 @@ export default function DashboardApp({ controller, onRequestClose, onHeaderReady
           ) : null}
           <button type="button" className="bp3-button bp3-small" onClick={handleRefresh}>
             {ui.refresh}
+          </button>
+          <button
+            type="button"
+            className="bp3-button bp3-small"
+            onClick={() => controller?.openSettings?.()}
+            aria-label="Settings"
+            title="Open Better Tasks settings"
+          >
+            Settings
           </button>
           <button
             type="button"

--- a/src/dashboard/rowEstimate.js
+++ b/src/dashboard/rowEstimate.js
@@ -1,0 +1,66 @@
+const GROUP_ROW_PX = 30;
+const SUBTASK_ROW_PX = 80;
+const FLOATING_DASHBOARD_WIDTH_PX = 620;
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+function pillDisplayValue(pill) {
+  return String(pill?.value ?? pill?.raw ?? "");
+}
+
+function estimatePillRows(pills, availableWidth) {
+  if (!Array.isArray(pills) || pills.length === 0) return 0;
+  const gap = 6;
+  let rows = 1;
+  let used = 0;
+  for (const pill of pills) {
+    // Blueprint's small pill text averages about 5px per character. Project
+    // pills are allowed to consume a whole line, matching their max-width.
+    const textWidth = pill?.type === "project" ? 34 : 38;
+    const width = clamp(textWidth + pillDisplayValue(pill).length * 5, 48, availableWidth);
+    if (used > 0 && used + gap + width > availableWidth) {
+      rows += 1;
+      used = width;
+    } else {
+      used += (used > 0 ? gap : 0) + width;
+    }
+  }
+  return rows;
+}
+
+/**
+ * Estimate a dashboard virtual row before it has ever been mounted.
+ *
+ * TanStack Virtual corrects estimates with ResizeObserver after mounting. A
+ * close first estimate keeps the scroll range stable instead of progressively
+ * growing as the user discovers rows for the first time.
+ */
+export function estimateDashboardRowSize(
+  row,
+  { viewportWidth = FLOATING_DASHBOARD_WIDTH_PX, mobile = false } = {}
+) {
+  if (row?.type === "group") return GROUP_ROW_PX;
+  if (row?.type === "subtask") return SUBTASK_ROW_PX;
+
+  const task = row?.task || {};
+  const title = String(task.title || "");
+  const notes = String(task.metadata?.notes || "");
+  const bodyWidth = Math.max(220, viewportWidth - (mobile ? 92 : 224));
+  const pillWidth = Math.max(200, viewportWidth - (mobile ? 84 : 256));
+  const charsPerLine = Math.max(28, Math.floor(bodyWidth / 7));
+  const titleLines = clamp(Math.ceil(Math.max(1, title.length) / charsPerLine), 1, 6);
+  const titleHeight = titleLines * 23;
+  const notesHeight = notes ? (notes.length > charsPerLine ? 40 : 24) + 8 : 0;
+  const pillRows = estimatePillRows(task.metaPills, pillWidth);
+  const pillHeight = pillRows > 0 ? 24 + (pillRows - 1) * 30 : 0;
+
+  // 62px covers row padding, page context and desktop actions. This formula
+  // matches the dashboard's observed 109px compact rows and 200px+ rich rows.
+  return 62 + titleHeight + notesHeight + pillHeight;
+}
+
+export const DASHBOARD_ROW_ESTIMATE_DEFAULTS = Object.freeze({
+  group: GROUP_ROW_PX,
+  subtask: SUBTASK_ROW_PX,
+  floatingWidth: FLOATING_DASHBOARD_WIDTH_PX,
+});

--- a/src/dashboard/rowEstimate.js
+++ b/src/dashboard/rowEstimate.js
@@ -8,6 +8,7 @@ export function visibleDashboardText(value) {
   return String(value ?? "")
     .replace(/\[([^\]]+)\]\(\(\([^)]*\)\)\)/g, "$1")
     .replace(/\[\[([^\]]+)\]\]/g, "$1")
+    .replace(/\(\(([A-Za-z0-9_-]{9})\)\)/g, "$1")
     .replace(/(?:\*\*|__|~~|\^\^|`)/g, "");
 }
 
@@ -50,7 +51,7 @@ export function estimateDashboardRowSize(
   if (row?.type === "subtask") return SUBTASK_ROW_PX;
 
   const task = row?.task || {};
-  const title = visibleDashboardText(task.title || "");
+  const title = visibleDashboardText(task.displayTitle || task.title || "");
   const notes = visibleDashboardText(task.metadata?.notes || "");
   const bodyWidth = Math.max(220, viewportWidth - (mobile ? 92 : 224));
   const pillWidth = Math.max(200, viewportWidth - (mobile ? 84 : 256));

--- a/src/dashboard/rowEstimate.js
+++ b/src/dashboard/rowEstimate.js
@@ -4,8 +4,15 @@ const FLOATING_DASHBOARD_WIDTH_PX = 620;
 
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
 
+export function visibleDashboardText(value) {
+  return String(value ?? "")
+    .replace(/\[([^\]]+)\]\(\(\([^)]*\)\)\)/g, "$1")
+    .replace(/\[\[([^\]]+)\]\]/g, "$1")
+    .replace(/(?:\*\*|__|~~|\^\^|`)/g, "");
+}
+
 function pillDisplayValue(pill) {
-  return String(pill?.value ?? pill?.raw ?? "");
+  return visibleDashboardText(pill?.value ?? pill?.raw ?? "");
 }
 
 function estimatePillRows(pills, availableWidth) {
@@ -43,8 +50,8 @@ export function estimateDashboardRowSize(
   if (row?.type === "subtask") return SUBTASK_ROW_PX;
 
   const task = row?.task || {};
-  const title = String(task.title || "");
-  const notes = String(task.metadata?.notes || "");
+  const title = visibleDashboardText(task.title || "");
+  const notes = visibleDashboardText(task.metadata?.notes || "");
   const bodyWidth = Math.max(220, viewportWidth - (mobile ? 92 : 224));
   const pillWidth = Math.max(200, viewportWidth - (mobile ? 84 : 256));
   const charsPerLine = Math.max(28, Math.floor(bodyWidth / 7));

--- a/src/dashboard/scrollIdleGate.js
+++ b/src/dashboard/scrollIdleGate.js
@@ -1,0 +1,120 @@
+export function createScrollIdleGate({
+  windowLike = typeof window !== "undefined" ? window : null,
+  quietMs = 160,
+  idleTimeoutMs = 800,
+} = {}) {
+  let disposed = false;
+  let scrolling = false;
+  let scrollTimer = null;
+  const pending = new Set();
+  const scheduled = new Map();
+
+  const scheduleTimeout = (callback, delay) => {
+    if (typeof windowLike?.setTimeout === "function") {
+      return windowLike.setTimeout(callback, delay);
+    }
+    return setTimeout(callback, delay);
+  };
+
+  const cancelTimeout = (id) => {
+    if (id == null) return;
+    if (typeof windowLike?.clearTimeout === "function") {
+      windowLike.clearTimeout(id);
+      return;
+    }
+    clearTimeout(id);
+  };
+
+  const cancelScheduled = (resolve) => {
+    const entry = scheduled.get(resolve);
+    if (!entry) return;
+    scheduled.delete(resolve);
+    if (entry.kind === "idle" && typeof windowLike?.cancelIdleCallback === "function") {
+      windowLike.cancelIdleCallback(entry.id);
+    } else {
+      cancelTimeout(entry.id);
+    }
+  };
+
+  const finish = (resolve) => {
+    cancelScheduled(resolve);
+    if (!pending.delete(resolve)) return;
+    resolve();
+  };
+
+  const schedule = (resolve) => {
+    if (!pending.has(resolve) || scheduled.has(resolve)) return;
+    if (disposed) {
+      finish(resolve);
+      return;
+    }
+    if (scrolling) return;
+
+    const run = () => {
+      scheduled.delete(resolve);
+      if (disposed || !scrolling) {
+        finish(resolve);
+      }
+      // If scrolling resumed, the waiter remains pending and markScrollEnd()
+      // will schedule it again after the quiet boundary.
+    };
+
+    if (typeof windowLike?.requestIdleCallback === "function") {
+      const id = windowLike.requestIdleCallback(run, { timeout: idleTimeoutMs });
+      scheduled.set(resolve, { kind: "idle", id });
+    } else {
+      const id = scheduleTimeout(run, 0);
+      scheduled.set(resolve, { kind: "timeout", id });
+    }
+  };
+
+  const schedulePending = () => {
+    for (const resolve of pending) schedule(resolve);
+  };
+
+  const markScrollEnd = () => {
+    if (disposed) return;
+    if (scrollTimer != null) {
+      cancelTimeout(scrollTimer);
+      scrollTimer = null;
+    }
+    scrolling = false;
+    schedulePending();
+  };
+
+  const markScroll = () => {
+    if (disposed) return;
+    scrolling = true;
+    for (const resolve of pending) cancelScheduled(resolve);
+    if (scrollTimer != null) cancelTimeout(scrollTimer);
+    scrollTimer = scheduleTimeout(markScrollEnd, quietMs);
+  };
+
+  const wait = () => new Promise((resolve) => {
+    if (disposed) {
+      resolve();
+      return;
+    }
+    pending.add(resolve);
+    schedule(resolve);
+  });
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    scrolling = false;
+    if (scrollTimer != null) {
+      cancelTimeout(scrollTimer);
+      scrollTimer = null;
+    }
+    for (const resolve of [...pending]) finish(resolve);
+  };
+
+  return {
+    markScroll,
+    markScrollEnd,
+    wait,
+    dispose,
+    isScrolling: () => scrolling,
+  };
+}

--- a/src/dashboard/scrollStability.js
+++ b/src/dashboard/scrollStability.js
@@ -1,0 +1,11 @@
+/**
+ * Keep the browser's physical scroll offset authoritative while virtual rows
+ * settle. TanStack's default estimate correction writes scrollTop after a
+ * ResizeObserver measurement; with trackpad momentum that write can arrive
+ * just after scroll end and look like a brief freeze followed by a nudge.
+ * Dashboard estimates are deliberately close enough that preserving the
+ * user's offset is the less surprising behavior.
+ */
+export function shouldAdjustDashboardScrollPositionOnItemSizeChange() {
+  return false;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,7 @@ import {
 } from "./core/page-refs";
 import { parseBtQuery, KNOWN_KEYS as BT_QUERY_KNOWN_KEYS } from "./core/bt-query-parser";
 import { parseAttributeEditTarget } from "./core/attribute-edit";
+import { buildDirectParentUidQuery } from "./core/direct-parent";
 import {
   normalizePulledSubtree,
   flattenSubtreeToCreateSteps,
@@ -15318,12 +15319,7 @@ export default {
 
     async function getParentUid(childUid) {
       const safeChildUid = escapeDatalogString(childUid);
-      const res = await window.roamAlphaAPI.q(`
-        [:find ?puid
-         :where
-         [?c :block/uid "${safeChildUid}"]
-         [?c :block/parents ?p]
-         [?p :block/uid ?puid]]`);
+      const res = await window.roamAlphaAPI.q(buildDirectParentUidQuery(safeChildUid));
       return res?.[0]?.[0] || null;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ import { parseBtQuery, KNOWN_KEYS as BT_QUERY_KNOWN_KEYS } from "./core/bt-query
 import { parseAttributeEditTarget } from "./core/attribute-edit";
 import { buildDirectParentUidQuery } from "./core/direct-parent";
 import { scheduleDashboardWarmup } from "./core/dashboard-warmup";
+import { openBetterTasksSettings } from "./core/open-settings";
 import {
   normalizePulledSubtree,
   flattenSubtreeToCreateSteps,
@@ -1480,6 +1481,16 @@ export default {
 
     const config = buildSettingsConfig();
     extensionAPI.settings.panel.create(config);
+
+    extensionAPI.ui.commandPalette.addCommand({
+      label: "Better Tasks: Open settings",
+      callback: async () => {
+        const opened = await openBetterTasksSettings();
+        if (!opened) {
+          toast(t("toasts.openSettings", getLanguageSetting()) || "Open Roam Depot, then choose Better Tasks under Extension Settings.");
+        }
+      },
+    });
 
     if (extensionAPI.settings.get(ACTIVITY_LOG_ENABLED_SETTING) == null) {
       extensionAPI.settings.set(ACTIVITY_LOG_ENABLED_SETTING, true);
@@ -17369,11 +17380,10 @@ export default {
         }
       }
 
-      function openSettings() {
+      async function openSettings() {
         try {
-          if (extensionAPI?.settings?.open) {
-            extensionAPI.settings.open();
-          } else {
+          const opened = await openBetterTasksSettings();
+          if (!opened) {
             toast("Open the Roam Depot settings for Better Tasks to adjust options.");
           }
         } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,7 @@ import {
   formatContextListForWrite,
 } from "./core/page-refs";
 import { parseBtQuery, KNOWN_KEYS as BT_QUERY_KNOWN_KEYS } from "./core/bt-query-parser";
+import { parseAttributeEditTarget } from "./core/attribute-edit";
 import {
   normalizePulledSubtree,
   flattenSubtreeToCreateSteps,
@@ -15287,23 +15288,20 @@ export default {
 
     // ========================= Child -> Props sync core =========================
     async function handleAnyEdit(evt) {
-      const set = S();
+      // This listener is registered on document in capture mode, so it sees
+      // every keystroke in Roam. Reject ordinary drafts before resolving a
+      // block UID, reading settings, or touching the graph API.
+      const edit = parseAttributeEditTarget(evt?.target);
+      if (!edit) return;
+
+      const attrNames = resolveAttributeNames();
+      let attrType = null;
+      if (edit.key === attrNames.repeatKey) attrType = "repeat";
+      else if (edit.key === attrNames.dueKey) attrType = "due";
+      if (!attrType) return;
 
       const uid = findBlockUidFromElement(evt.target);
       if (!uid) return;
-
-      // Is this block a "repeat:: ..." or "due:: ..." child?
-      const child = await getBlock(uid);
-      const line = (child?.string || "").trim();
-      const m = line.match(ATTR_RE);
-      if (!m) return;
-
-      const key = m[1].trim().toLowerCase();
-      const attrNames = set.attrNames;
-      let attrType = null;
-      if (key === attrNames.repeatKey) attrType = "repeat";
-      else if (key === attrNames.dueKey) attrType = "due";
-      if (!attrType) return;
 
       // Get parent task uid
       const parentUid = await getParentUid(uid);

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ import { scheduleDashboardWarmup } from "./core/dashboard-warmup";
 import { createAnalyticsCache } from "./core/analytics-cache";
 import { openBetterTasksSettings } from "./core/open-settings";
 import { resolveBlockReferences } from "./core/block-references";
+import { getThemeObserverRegistrations } from "./core/theme-observer";
 import {
   readSuggestionCountSnapshot,
   suggestionCountSnapshotKey,
@@ -20173,13 +20174,13 @@ function observeThemeChanges() {
     const cb = () => triggerThemeResync(180);
     themeObserver = new MutationObserver(cb);
     try {
-      const targets = [document.body, document.documentElement, document.head].filter(Boolean);
-      for (const target of targets) {
-        const opts =
-          target === document.head
-            ? { childList: true, subtree: true, attributes: true, attributeFilter: ["href", "data-theme"] }
-            : { attributes: true, attributeFilter: ["class", "data-theme"], subtree: true };
-        themeObserver.observe(target, opts);
+      const registrations = getThemeObserverRegistrations({
+        body: document.body,
+        documentElement: document.documentElement,
+        head: document.head,
+      });
+      for (const { target, options } of registrations) {
+        themeObserver.observe(target, options);
       }
     } catch (_) {
       themeObserver = null;

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,7 @@ import {
 import { parseBtQuery, KNOWN_KEYS as BT_QUERY_KNOWN_KEYS } from "./core/bt-query-parser";
 import { parseAttributeEditTarget } from "./core/attribute-edit";
 import { buildDirectParentUidQuery } from "./core/direct-parent";
+import { scheduleDashboardWarmup } from "./core/dashboard-warmup";
 import {
   normalizePulledSubtree,
   flattenSubtreeToCreateSteps,
@@ -363,6 +364,7 @@ let pillDomCountsCache = { at: 0, blockCount: null, checkboxCount: null };
 
 let lastAttrNames = null;
 let activeDashboardController = null;
+let dashboardWarmupCleanup = null;
 let dashboardEverOpened = false;
 const dashboardWatchers = new Map();
 let topbarButtonObserver = null;
@@ -1714,6 +1716,10 @@ export default {
     }
 
     activeDashboardController = createDashboardController(extensionAPI);
+    dashboardWarmupCleanup?.();
+    dashboardWarmupCleanup = scheduleDashboardWarmup(activeDashboardController, {
+      windowLike: typeof window !== "undefined" ? window : null,
+    });
     registerExtensionToolsAPI();
 
     try {
@@ -16768,7 +16774,11 @@ export default {
             language={getLanguageSetting()}
           />
         );
-        ensureInitialLoad();
+        // Let React commit the dashboard shell before any graph-wide task
+        // collection starts. Usually the idle warm-up has already populated
+        // state; on a very early click this guarantees visible feedback by the
+        // next frame instead of a blank/white pause.
+        requestAnimationFrame(() => ensureInitialLoad());
         setTopbarActive(true);
         if (isFullPage) {
           requestAnimationFrame(() => enableFullPage());
@@ -19397,6 +19407,8 @@ export default {
     if (typeof teardownTodayPanelGlobal === "function") {
       await teardownTodayPanelGlobal();
     }
+    dashboardWarmupCleanup?.();
+    dashboardWarmupCleanup = null;
     if (activeDashboardController) {
       try {
         activeDashboardController.dispose?.();

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,12 @@ import { parseAttributeEditTarget } from "./core/attribute-edit";
 import { buildDirectParentUidQuery } from "./core/direct-parent";
 import { scheduleDashboardWarmup } from "./core/dashboard-warmup";
 import { openBetterTasksSettings } from "./core/open-settings";
+import { resolveBlockReferences } from "./core/block-references";
+import {
+  readSuggestionCountSnapshot,
+  suggestionCountSnapshotKey,
+  writeSuggestionCountSnapshot,
+} from "./core/suggestion-snapshot";
 import {
   normalizePulledSubtree,
   flattenSubtreeToCreateSteps,
@@ -4918,8 +4924,22 @@ export default {
     let analyticsCache = null;
 
     // ========================= Smart Suggestions caches =========================
-    let suggestionsCache = null; // { data, computedAt } — 30s TTL, analytics model
+    let suggestionsCache = null; // { data, computedAt, complete } — 30s TTL
     const SUGGESTIONS_CACHE_TTL_MS = 30000;
+    const currentGraphName = (() => {
+      try {
+        return window.roamAlphaAPI?.graph?.name?.() || "default";
+      } catch (_) {
+        return "default";
+      }
+    })();
+    const suggestionsCountStorageKey = suggestionCountSnapshotKey(currentGraphName);
+    let suggestionsCountSnapshot = readSuggestionCountSnapshot(
+      typeof window !== "undefined" ? window.localStorage : null,
+      suggestionsCountStorageKey
+    );
+    const dashboardBlockRefTitleCache = new Map();
+    const dashboardPageUidCache = new Map();
     // uid → { count, editedAt, at }. Valid only when editedAt still matches the
     // task AND the entry is younger than the TTL — :edit/time does not reliably
     // move when a grandchild activity event is written, so editedAt alone is
@@ -4930,6 +4950,7 @@ export default {
     const SNOOZE_COUNT_TTL_MS = 5 * 60 * 1000;
     const SNOOZE_FANOUT_CAP = 200; // hard bound on activity-log reads per compute
     const SNOOZE_FANOUT_CHUNK = 5;
+    const SNOOZE_BACKGROUND_CHUNK = 2;
     let snoozeFanoutCapWarned = false;
 
     // ========================= Dependency / blocked-state helpers =========================
@@ -15623,6 +15644,8 @@ export default {
         bulkUpdateMetadata,
         openBlock,
         openPage,
+        resolveBlockRefTitle: resolveDashboardBlockRefTitle,
+        resolvePageUid: resolveDashboardPageUid,
         notifyBlockChange,
         removeTask,
         openSettings,
@@ -15697,6 +15720,7 @@ export default {
         getWeekStart: () => getWeekStartSetting(),
         computeSuggestions: computeDashboardSuggestions,
         getSuggestionsCached,
+        getSuggestionsCountCached,
         dismissSuggestion,
         acceptSuggestion,
         getSuggestionSettings,
@@ -16154,7 +16178,7 @@ export default {
       // they exist. Bounded fan-out: only tasks the snooze rule can act on,
       // cache-first, at most SNOOZE_FANOUT_CAP uncached reads per pass in
       // small sequential chunks so a large graph cannot freeze the tab.
-      async function collectSnoozeCounts(tasks) {
+      async function collectSnoozeCounts(tasks, options = {}) {
         if (!activityLogEnabled()) return null;
         const candidates = tasks.filter(
           (task) =>
@@ -16180,8 +16204,12 @@ export default {
             );
           }
         }
-        for (let i = 0; i < toRead.length; i += SNOOZE_FANOUT_CHUNK) {
-          const chunk = toRead.slice(i, i + SNOOZE_FANOUT_CHUNK);
+        const chunkSize = options.background ? SNOOZE_BACKGROUND_CHUNK : SNOOZE_FANOUT_CHUNK;
+        for (let i = 0; i < toRead.length; i += chunkSize) {
+          if (options.background && typeof options.yieldToMainThread === "function") {
+            await options.yieldToMainThread();
+          }
+          const chunk = toRead.slice(i, i + chunkSize);
           await Promise.all(
             chunk.map(async (task) => {
               try {
@@ -16198,6 +16226,18 @@ export default {
         while (snoozeCountCache.size > SNOOZE_COUNT_CACHE_MAX) {
           const oldest = snoozeCountCache.keys().next().value;
           snoozeCountCache.delete(oldest);
+        }
+        return counts;
+      }
+
+      function collectCachedSnoozeCounts(tasks) {
+        const counts = new Map();
+        const nowMs = Date.now();
+        for (const task of tasks || []) {
+          const entry = task?.uid ? snoozeCountCache.get(task.uid) : null;
+          if (entry && entry.editedAt === task.editedAt && nowMs - entry.at < SNOOZE_COUNT_TTL_MS) {
+            counts.set(task.uid, entry.count);
+          }
         }
         return counts;
       }
@@ -16219,7 +16259,9 @@ export default {
             .map((m) => ({ completedAt: m.completedAt, dueAt: m.dueAt instanceof Date ? m.dueAt : null }));
           series.push({
             seriesId,
-            title: (open.length ? open[0].title : members[members.length - 1]?.title) || "",
+            title: (open.length
+              ? (open[0].displayTitle || open[0].title)
+              : (members[members.length - 1]?.displayTitle || members[members.length - 1]?.title)) || "",
             openMember,
             completions,
             stats: computeSeriesStreaks(members),
@@ -16232,17 +16274,19 @@ export default {
 
       async function computeDashboardSuggestions(options = {}) {
         const includeDismissed = options.includeDismissed === true;
+        const fast = options.fast === true;
         if (
           !includeDismissed &&
           suggestionsCache &&
+          (fast || suggestionsCache.complete !== false) &&
           Date.now() - suggestionsCache.computedAt < SUGGESTIONS_CACHE_TTL_MS
         ) {
           return suggestionsCache.data;
         }
         // The badge warm-up and a panel open can race — share one compute.
         if (!includeDismissed && suggestionsComputePromise) return suggestionsComputePromise;
-        const run = computeDashboardSuggestionsUncached(includeDismissed);
-        if (!includeDismissed) {
+        const run = computeDashboardSuggestionsUncached(includeDismissed, options);
+        if (!includeDismissed && !fast) {
           suggestionsComputePromise = run.finally(() => {
             suggestionsComputePromise = null;
           });
@@ -16251,25 +16295,39 @@ export default {
         return run;
       }
 
-      async function computeDashboardSuggestionsUncached(includeDismissed) {
+      async function computeDashboardSuggestionsUncached(includeDismissed, options = {}) {
+        const fast = options.fast === true;
         const suggestionSettings = getSuggestionSettings();
         const logEnabled = activityLogEnabled();
         if (!suggestionSettings.enabled) {
           const empty = { suggestions: [], computedAt: Date.now(), activityLogEnabled: logEnabled };
-          suggestionsCache = { data: empty, computedAt: Date.now() };
+          suggestionsCache = { data: empty, computedAt: Date.now(), complete: true };
+          persistSuggestionsCount(0);
           return empty;
         }
-        const tasks = await collectDashboardTasks({
-          includeCompleted: true,
-          attachWatches: false,
-          cacheKey: "suggestions",
-        });
+        const tasks = state.tasks.length
+          ? state.tasks
+          : await collectDashboardTasks({
+            includeCompleted: true,
+            attachWatches: false,
+            cacheKey: "dash:withDone",
+          });
         const all = Array.isArray(tasks) ? tasks : [];
         const now = new Date();
-        const snoozeCounts = await collectSnoozeCounts(all);
+        const snoozeCounts = fast
+          ? collectCachedSnoozeCounts(all)
+          : await collectSnoozeCounts(all, options);
         const series = buildSuggestionSeriesInput();
+        const suggestionTasks = all.map((task) => (
+          task?.displayTitle && task.displayTitle !== task.title
+            ? { ...task, title: task.displayTitle }
+            : task
+        ));
+        if (options.background && typeof options.yieldToMainThread === "function") {
+          await options.yieldToMainThread();
+        }
         const computed = computeSuggestionsCore(
-          { tasks: all, snoozeCounts, series },
+          { tasks: suggestionTasks, snoozeCounts, series },
           {
             now,
             thresholds: {
@@ -16279,6 +16337,9 @@ export default {
             enabledRules: suggestionSettings.rules,
           }
         );
+        if (options.background && typeof options.yieldToMainThread === "function") {
+          await options.yieldToMainThread();
+        }
         // Prune the dismissal store while the live subject set is at hand.
         const subjects = new Set();
         for (const task of all) subjects.add(task.uid);
@@ -16292,13 +16353,29 @@ export default {
           ? computed
           : filterDismissedSuggestions(computed, entries, { now });
         const data = { suggestions: visible, computedAt: Date.now(), activityLogEnabled: logEnabled };
-        if (!includeDismissed) suggestionsCache = { data, computedAt: Date.now() };
+        if (!includeDismissed) {
+          suggestionsCache = { data, computedAt: Date.now(), complete: !fast };
+          if (!fast) persistSuggestionsCount(visible.length);
+        }
         return data;
       }
 
       // Badge source — last computed result, possibly stale; never computes.
       function getSuggestionsCached() {
-        return suggestionsCache ? suggestionsCache.data : null;
+        return suggestionsCache?.complete !== false ? suggestionsCache?.data || null : null;
+      }
+
+      function getSuggestionsCountCached() {
+        if (suggestionsCache?.data?.suggestions) return suggestionsCache.data.suggestions.length;
+        return suggestionsCountSnapshot?.count ?? null;
+      }
+
+      function persistSuggestionsCount(count) {
+        suggestionsCountSnapshot = writeSuggestionCountSnapshot(
+          typeof window !== "undefined" ? window.localStorage : null,
+          suggestionsCountStorageKey,
+          count
+        ) || suggestionsCountSnapshot;
       }
 
       // Keep the cached list (and therefore the badge) accurate after an
@@ -16311,7 +16388,9 @@ export default {
             suggestions: suggestionsCache.data.suggestions.filter((s) => s.id !== id),
           },
           computedAt: suggestionsCache.computedAt,
+          complete: suggestionsCache.complete,
         };
+        persistSuggestionsCount(suggestionsCache.data.suggestions.length);
       }
 
       function dismissSuggestion(id) {
@@ -17397,6 +17476,7 @@ export default {
         // to avoid stale intermediate states from Roam's pull watchers
         if (bulkOperationInProgress) return;
         try {
+          dashboardBlockRefTitleCache.delete(uid);
           const set = S();
           invalidateBlockCache(uid);
           const block = await getBlock(uid);
@@ -18238,6 +18318,7 @@ export default {
     function deriveDashboardTask(block, meta, set) {
       if (!block) return null;
       const title = formatDashboardTitle(block.string || "");
+      const displayTitle = resolveBlockReferences(title, resolveDashboardBlockRefTitle);
       const attrCompleted = meta?.completed || meta?.childAttrMap?.completed?.value || null;
       const isCompleted = isBlockCompleted(block) || !!attrCompleted;
       const completedAtRaw = meta?.childAttrMap?.completed?.value || null;
@@ -18270,6 +18351,7 @@ export default {
         uid: block.uid,
         text: block.string || "",
         title,
+        displayTitle,
         pageUid: block.page?.uid || null,
         pageTitle: block.page?.title || block.page?.["node/title"] || "",
         repeatText: meta?.repeat || "",
@@ -18415,6 +18497,42 @@ export default {
         .replace(/^\s*\{\{\s*\[\[\s*(?:TODO|DONE)\s*\]\]\s*\}\}\s*/i, "")
         .replace(/^\s*(?:TODO|DONE)\s+/i, "")
         .trim();
+    }
+
+    function resolveDashboardBlockRefTitle(uid) {
+      if (!uid || typeof uid !== "string") return null;
+      if (dashboardBlockRefTitleCache.has(uid)) return dashboardBlockRefTitleCache.get(uid);
+      let value = null;
+      try {
+        const pulled = window.roamAlphaAPI?.data?.pull?.(
+          "[:block/string]",
+          [":block/uid", uid]
+        );
+        const raw = pulled?.[":block/string"] ?? pulled?.string ?? null;
+        value = typeof raw === "string" ? formatDashboardTitle(raw) : null;
+      } catch (_) {
+        value = null;
+      }
+      dashboardBlockRefTitleCache.set(uid, value);
+      return value;
+    }
+
+    function resolveDashboardPageUid(title) {
+      const name = typeof title === "string" ? title.trim() : "";
+      if (!name) return null;
+      if (dashboardPageUidCache.has(name)) return dashboardPageUidCache.get(name);
+      let uid = null;
+      try {
+        const pulled = window.roamAlphaAPI?.data?.pull?.(
+          "[:block/uid]",
+          [":node/title", name]
+        );
+        uid = pulled?.[":block/uid"] || null;
+      } catch (_) {
+        uid = null;
+      }
+      dashboardPageUidCache.set(name, uid);
+      return uid;
     }
 
     function formatDateDisplay(date, set) {

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ import { parseBtQuery, KNOWN_KEYS as BT_QUERY_KNOWN_KEYS } from "./core/bt-query
 import { parseAttributeEditTarget } from "./core/attribute-edit";
 import { buildDirectParentUidQuery } from "./core/direct-parent";
 import { scheduleDashboardWarmup } from "./core/dashboard-warmup";
+import { createAnalyticsCache } from "./core/analytics-cache";
 import { openBetterTasksSettings } from "./core/open-settings";
 import { resolveBlockReferences } from "./core/block-references";
 import {
@@ -4921,7 +4922,7 @@ export default {
     // ========================= Recurring series index (populated by collectDashboardTasks) ===
     // Map<seriesId, { members: DashboardTask[] }> — groups tasks sharing the same rt.parent / rt.id
     let dashboardSeriesIndex = new Map();
-    let analyticsCache = null;
+    const analyticsCache = createAnalyticsCache();
 
     // ========================= Smart Suggestions caches =========================
     let suggestionsCache = null; // { data, computedAt, complete } — 30s TTL
@@ -12375,6 +12376,7 @@ export default {
           box-sizing: border-box;
           padding: 6px 8px;
           margin-left: 14px;
+          container-type: inline-size;
         }
         .bt-today-panel__header {
           display: flex;
@@ -12414,7 +12416,10 @@ export default {
           color: inherit;
           min-width: 0;
           flex: 1 1 auto;
-          word-break: break-word;
+          white-space: normal;
+          overflow-wrap: anywhere;
+          word-break: normal;
+          line-height: 1.4;
         }
         .bt-today-panel__item--completed .bt-today-panel__row-title {
           text-decoration: line-through;
@@ -12428,6 +12433,19 @@ export default {
           gap: 6px;
           flex-shrink: 0;
           white-space: nowrap;
+        }
+        @container (max-width: 420px) {
+          .bt-today-panel__row {
+            flex-wrap: wrap;
+            align-items: flex-start;
+          }
+          .bt-today-panel__row-title {
+            flex-basis: 100%;
+          }
+          .bt-today-panel__row-actions {
+            width: 100%;
+            justify-content: flex-end;
+          }
         }
         .bt-today-panel__icon-btn {
           border: 1px solid var(--bt-border, rgba(0,0,0,0.22));
@@ -15724,20 +15742,20 @@ export default {
         dismissSuggestion,
         acceptSuggestion,
         getSuggestionSettings,
-        computeAnalytics: async (period) => {
-          const ANALYTICS_CACHE_TTL = 30000;
-          if (
-            analyticsCache &&
-            analyticsCache.period === period &&
-            Date.now() - analyticsCache.computedAt < ANALYTICS_CACHE_TTL
-          ) {
-            return analyticsCache.data;
-          }
-          const tasks = await collectDashboardTasks({
-            includeCompleted: true,
-            attachWatches: false,
-            cacheKey: "analytics",
-          });
+        getAnalyticsCached: (period = "30d") => analyticsCache.get(period) || null,
+        warmAnalyticsCache,
+        computeAnalytics: async (period = "30d") => {
+          const cached = analyticsCache.get(period);
+          if (cached) return cached;
+          // The dashboard model already contains open and completed tasks. Reuse
+          // it instead of issuing a second graph-wide query on first open.
+          const tasks = state.status === "ready" || state.tasks.length
+            ? state.tasks
+            : await collectDashboardTasks({
+                includeCompleted: true,
+                attachWatches: false,
+                cacheKey: "dash:withDone",
+              });
           const all = Array.isArray(tasks) ? tasks : [];
           const now = new Date();
           const todayISO = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
@@ -15925,7 +15943,7 @@ export default {
             recurringAdherence: { avgOnTimeRate, totalSeries: seriesCount, topPerformers, bottomPerformers },
             heatmap: { byDayOfWeek, byDate: heatmapByDate },
           };
-          analyticsCache = { period, data, computedAt: Date.now() };
+          analyticsCache.set(period, data);
           return data;
         },
         isDashboardFullPage: () => !!isFullPage,
@@ -16499,12 +16517,27 @@ export default {
 
       function ensureInitialLoad() {
         if (state.status === "idle" && !refreshPromise) {
-          void refresh({ reason: "initial" });
+          return refresh({ reason: "initial" });
         }
+        return refreshPromise || Promise.resolve(state);
+      }
+
+      async function warmAnalyticsCache({
+        periods = ["30d", "7d", "90d", "all"],
+        yieldToMainThread = null,
+        isCancelled = null,
+      } = {}) {
+        await ensureInitialLoad();
+        await analyticsCache.warm({
+          periods,
+          yieldToMainThread,
+          isCancelled,
+          compute: (period) => controller.computeAnalytics(period),
+        });
       }
 
       async function refresh({ reason = "manual" } = {}) {
-        analyticsCache = null;
+        analyticsCache.clear();
         suggestionsCache = null;
         if (refreshPromise) return refreshPromise;
         state = {
@@ -17426,6 +17459,7 @@ export default {
         removeDashboardWatch(uid);
         const tasks = state.tasks.filter((task) => task.uid !== uid);
         if (tasks.length === state.tasks.length) return;
+        analyticsCache.clear();
         state = { ...state, tasks };
         emit();
       }
@@ -17718,6 +17752,7 @@ export default {
             task.parentTaskUid === oldEntry.parentTaskUid &&
             !parentTaskModified;
           if (subtasksSame) return;
+          analyticsCache.clear();
           state = { ...state, tasks: sortDashboardTasksList(tasks) };
           emit();
           if (controller.isOpen()) {
@@ -17745,7 +17780,7 @@ export default {
       }
 
       function dispose() {
-        analyticsCache = null;
+        analyticsCache.clear();
         suggestionsCache = null;
         snoozeCountCache.clear();
         subscribers.clear();
@@ -19215,7 +19250,9 @@ export default {
         (options.includeOverdue && sections.overdue.length);
       const signatureParts = [];
       const pushSection = (arr) =>
-        signatureParts.push(...(arr || []).map((t) => `${t.uid}:${t.isCompleted ? "done" : "todo"}`));
+        signatureParts.push(...(arr || []).map((t) =>
+          `${t.uid}:${t.isCompleted ? "done" : "todo"}:${t.displayTitle || t.title || ""}`
+        ));
       pushSection(sections.startingToday);
       pushSection(sections.deferredToToday);
       pushSection(sections.dueToday);
@@ -19255,7 +19292,8 @@ export default {
           const titleBtn = document.createElement("button");
           titleBtn.type = "button";
           titleBtn.className = "bt-today-panel__row-title";
-          titleBtn.textContent = (task.isBlocked ? "🔒 " : "") + (task.title || todayStrings.untitled || "(Untitled)");
+          titleBtn.textContent = (task.isBlocked ? "🔒 " : "")
+            + (task.displayTitle || task.title || todayStrings.untitled || "(Untitled)");
           titleBtn.addEventListener("click", (e) => {
             const openInSidebar = !!e?.shiftKey;
             if (openInSidebar) {

--- a/tests/analytics-cache.test.mjs
+++ b/tests/analytics-cache.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createAnalyticsCache } from "../src/core/analytics-cache.js";
+
+test("analytics cache keeps every period until the task model changes", () => {
+  const cache = createAnalyticsCache();
+  cache.set("7d", { completed: 2 });
+  cache.set("30d", { completed: 8 });
+
+  assert.deepEqual(cache.get("7d"), { completed: 2 });
+  assert.deepEqual(cache.get("30d"), { completed: 8 });
+
+  cache.clear();
+  assert.equal(cache.get("7d"), null);
+  assert.equal(cache.get("30d"), null);
+});
+
+test("analytics warming yields between periods and skips cached work", async () => {
+  const cache = createAnalyticsCache();
+  cache.set("30d", { period: "30d" });
+  const events = [];
+
+  await cache.warm({
+    periods: ["30d", "7d", "90d"],
+    yieldToMainThread: async () => { events.push("yield"); },
+    compute: async (period) => {
+      events.push(period);
+      return { period };
+    },
+  });
+
+  assert.deepEqual(events, ["yield", "7d", "yield", "90d"]);
+  assert.equal(cache.get("7d").period, "7d");
+  assert.equal(cache.get("90d").period, "90d");
+});
+
+test("analytics warming stops before computation when scrolling resumes", async () => {
+  const cache = createAnalyticsCache();
+  let cancelled = false;
+  let computes = 0;
+
+  await cache.warm({
+    periods: ["30d", "7d"],
+    yieldToMainThread: async () => { cancelled = true; },
+    isCancelled: () => cancelled,
+    compute: async () => { computes += 1; return {}; },
+  });
+
+  assert.equal(computes, 0);
+});

--- a/tests/attribute-edit.test.mjs
+++ b/tests/attribute-edit.test.mjs
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseAttributeEditTarget } from "../src/core/attribute-edit.js";
+
+test("ordinary Roam typing exits the attribute-edit hot path", () => {
+  const ordinaryDrafts = [
+    "Write a normal sentence",
+    "[[Page reference]]",
+    "((block-ref))",
+    "{{[[TODO]]}} Finish this",
+    "=ROUND(B4*C4/100,2)",
+    "",
+  ];
+
+  for (const value of ordinaryDrafts) {
+    assert.equal(parseAttributeEditTarget({ value }), null, value);
+  }
+});
+
+test("attribute child drafts are classified without a graph read", () => {
+  assert.deepEqual(parseAttributeEditTarget({ value: "repeat:: every weekday" }), {
+    key: "repeat",
+    value: "every weekday",
+  });
+  assert.deepEqual(parseAttributeEditTarget({ value: "  Due Date :: [[August 4th, 2026]]  " }), {
+    key: "due date",
+    value: "[[August 4th, 2026]]",
+  });
+});
+
+test("contenteditable attribute drafts are supported", () => {
+  assert.deepEqual(
+    parseAttributeEditTarget({ isContentEditable: true, textContent: "due:: tomorrow" }),
+    { key: "due", value: "tomorrow" }
+  );
+});
+
+test("non-editable targets and empty attribute values are ignored", () => {
+  assert.equal(parseAttributeEditTarget(null), null);
+  assert.equal(parseAttributeEditTarget({ textContent: "due:: tomorrow" }), null);
+  assert.equal(parseAttributeEditTarget({ value: "due::" }), null);
+});
+

--- a/tests/attribute-edit.test.mjs
+++ b/tests/attribute-edit.test.mjs
@@ -17,6 +17,16 @@ test("ordinary Roam typing exits the attribute-edit hot path", () => {
   }
 });
 
+test("ordinary drafts skip attribute parsing before any delimiter appears", () => {
+  const draft = {
+    get value() {
+      return "A long ordinary paragraph that never becomes an attribute";
+    },
+  };
+
+  assert.equal(parseAttributeEditTarget(draft), null);
+});
+
 test("attribute child drafts are classified without a graph read", () => {
   assert.deepEqual(parseAttributeEditTarget({ value: "repeat:: every weekday" }), {
     key: "repeat",
@@ -40,4 +50,3 @@ test("non-editable targets and empty attribute values are ignored", () => {
   assert.equal(parseAttributeEditTarget({ textContent: "due:: tomorrow" }), null);
   assert.equal(parseAttributeEditTarget({ value: "due::" }), null);
 });
-

--- a/tests/block-references.test.mjs
+++ b/tests/block-references.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  extractBlockReferenceUids,
+  resolveBlockReferences,
+} from "../src/core/block-references.js";
+
+test("extracts unique Roam block references in authored order", () => {
+  assert.deepEqual(
+    extractBlockReferenceUids("before ((xJuYmHX0v)) after ((abcdefghi)) and ((xJuYmHX0v))"),
+    ["xJuYmHX0v", "abcdefghi"]
+  );
+});
+
+test("resolves nested block references without exposing raw UIDs", () => {
+  const blocks = new Map([
+    ["xJuYmHX0v", "commit the dashboard changes and ((abcdefghi))"],
+    ["abcdefghi", "push the review build"],
+  ]);
+  assert.equal(
+    resolveBlockReferences("easier way: ((xJuYmHX0v))", (uid) => blocks.get(uid)),
+    "easier way: commit the dashboard changes and push the review build"
+  );
+});
+
+test("keeps missing and cyclic references safe", () => {
+  const blocks = new Map([
+    ["xJuYmHX0v", "loop ((abcdefghi))"],
+    ["abcdefghi", "back ((xJuYmHX0v))"],
+  ]);
+  assert.equal(
+    resolveBlockReferences("((missing00))", (uid) => blocks.get(uid)),
+    "((missing00))"
+  );
+  assert.match(
+    resolveBlockReferences("((xJuYmHX0v))", (uid) => blocks.get(uid)),
+    /\(\(xJuYmHX0v\)\)/
+  );
+});

--- a/tests/dashboard-row-estimate.test.mjs
+++ b/tests/dashboard-row-estimate.test.mjs
@@ -76,6 +76,22 @@ test("row estimates count visible Roam text instead of reference markup", () => 
   assert.equal(rich, plain);
 });
 
+test("resolved block-reference text drives the estimate instead of the raw UID", () => {
+  const resolved = estimateDashboardRowSize({
+    type: "task",
+    task: {
+      title: "See ((xJuYmHX0v))",
+      displayTitle: "See the full referenced task title which wraps onto another line",
+      metadata: {},
+    },
+  }, { viewportWidth: 360 });
+  const raw = estimateDashboardRowSize({
+    type: "task",
+    task: { title: "See ((xJuYmHX0v))", metadata: {} },
+  }, { viewportWidth: 360 });
+  assert.ok(resolved > raw);
+});
+
 test("exported defaults document the floating dashboard geometry", () => {
   assert.deepEqual(DASHBOARD_ROW_ESTIMATE_DEFAULTS, {
     group: 30,

--- a/tests/dashboard-row-estimate.test.mjs
+++ b/tests/dashboard-row-estimate.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   DASHBOARD_ROW_ESTIMATE_DEFAULTS,
   estimateDashboardRowSize,
+  visibleDashboardText,
 } from "../src/dashboard/rowEstimate.js";
 
 test("group and subtask estimates match their stable rendered heights", () => {
@@ -58,6 +59,21 @@ test("wider full-page layouts estimate fewer wraps", () => {
     estimateDashboardRowSize(row, { viewportWidth: 620 }) >
       estimateDashboardRowSize(row, { viewportWidth: 1200 })
   );
+});
+
+test("row estimates count visible Roam text instead of reference markup", () => {
+  assert.equal(visibleDashboardText("Review [[Long Project Name]] with **Alex**"), "Review Long Project Name with Alex");
+  assert.equal(visibleDashboardText("[Alias](((abcdefghi)))"), "Alias");
+
+  const plain = estimateDashboardRowSize({
+    type: "task",
+    task: { title: "Review Long Project Name with Alex", metadata: {} },
+  });
+  const rich = estimateDashboardRowSize({
+    type: "task",
+    task: { title: "Review [[Long Project Name]] with **Alex**", metadata: {} },
+  });
+  assert.equal(rich, plain);
 });
 
 test("exported defaults document the floating dashboard geometry", () => {

--- a/tests/dashboard-row-estimate.test.mjs
+++ b/tests/dashboard-row-estimate.test.mjs
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DASHBOARD_ROW_ESTIMATE_DEFAULTS,
+  estimateDashboardRowSize,
+} from "../src/dashboard/rowEstimate.js";
+
+test("group and subtask estimates match their stable rendered heights", () => {
+  assert.equal(estimateDashboardRowSize({ type: "group" }), 30);
+  assert.equal(estimateDashboardRowSize({ type: "subtask" }), 80);
+});
+
+test("compact rows no longer use the old 100px blanket guess", () => {
+  const size = estimateDashboardRowSize({
+    type: "task",
+    task: {
+      title: "Short task",
+      metadata: {},
+      metaPills: [{ type: "due", value: "Mon" }],
+    },
+  });
+  assert.equal(size, 109);
+});
+
+test("notes, wrapped titles, and wide project pills predict richer rows", () => {
+  const size = estimateDashboardRowSize({
+    type: "task",
+    task: {
+      title: "A long task title that wraps onto a second line in the floating dashboard view",
+      metadata: { notes: "A sufficiently long note that occupies both clamped note lines in the task row." },
+      metaPills: [
+        { type: "due", value: "Mon" },
+        { type: "project", value: "{{or: [[A long project name]] | [[Another project]] | +[[Active Projects]]}}" },
+        { type: "context", value: "computer" },
+        { type: "priority", value: "High" },
+        { type: "energy", value: "Medium" },
+      ],
+    },
+  });
+  assert.ok(size >= 210, `expected a rich row estimate, received ${size}`);
+});
+
+test("wider full-page layouts estimate fewer wraps", () => {
+  const row = {
+    type: "task",
+    task: {
+      title: "A fairly long task title that wraps in the compact floating dashboard",
+      metadata: { notes: "Some explanatory notes for the task." },
+      metaPills: [
+        { type: "due", value: "Monday" },
+        { type: "project", value: "[[Dashboard Performance]]" },
+        { type: "context", value: "computer" },
+      ],
+    },
+  };
+  assert.ok(
+    estimateDashboardRowSize(row, { viewportWidth: 620 }) >
+      estimateDashboardRowSize(row, { viewportWidth: 1200 })
+  );
+});
+
+test("exported defaults document the floating dashboard geometry", () => {
+  assert.deepEqual(DASHBOARD_ROW_ESTIMATE_DEFAULTS, {
+    group: 30,
+    subtask: 80,
+    floatingWidth: 620,
+  });
+});

--- a/tests/dashboard-scroll-idle-gate.test.mjs
+++ b/tests/dashboard-scroll-idle-gate.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createScrollIdleGate } from "../src/dashboard/scrollIdleGate.js";
+
+function fakeWindow() {
+  let nextId = 1;
+  const timers = new Map();
+  const idle = new Map();
+  return {
+    setTimeout(callback) {
+      const id = nextId++;
+      timers.set(id, callback);
+      return id;
+    },
+    clearTimeout(id) {
+      timers.delete(id);
+    },
+    requestIdleCallback(callback) {
+      const id = nextId++;
+      idle.set(id, callback);
+      return id;
+    },
+    cancelIdleCallback(id) {
+      idle.delete(id);
+    },
+    flushTimers() {
+      const callbacks = [...timers.values()];
+      timers.clear();
+      callbacks.forEach((callback) => callback());
+    },
+    flushIdle() {
+      const callbacks = [...idle.values()];
+      idle.clear();
+      callbacks.forEach((callback) => callback({ didTimeout: false, timeRemaining: () => 10 }));
+    },
+    pendingIdle: () => idle.size,
+  };
+}
+
+test("background work waits until scrolling ends and the browser is idle", async () => {
+  const windowLike = fakeWindow();
+  const gate = createScrollIdleGate({ windowLike });
+  gate.markScroll();
+  let resolved = false;
+  const pending = gate.wait().then(() => { resolved = true; });
+
+  windowLike.flushIdle();
+  await Promise.resolve();
+  assert.equal(resolved, false);
+
+  gate.markScrollEnd();
+  assert.equal(windowLike.pendingIdle(), 1);
+  windowLike.flushIdle();
+  await pending;
+  assert.equal(resolved, true);
+});
+
+test("a new scroll cancels queued idle work and requeues it after scrollend", async () => {
+  const windowLike = fakeWindow();
+  const gate = createScrollIdleGate({ windowLike });
+  let resolved = false;
+  const pending = gate.wait().then(() => { resolved = true; });
+  assert.equal(windowLike.pendingIdle(), 1);
+
+  gate.markScroll();
+  assert.equal(windowLike.pendingIdle(), 0);
+  windowLike.flushIdle();
+  await Promise.resolve();
+  assert.equal(resolved, false);
+
+  gate.markScrollEnd();
+  windowLike.flushIdle();
+  await pending;
+  assert.equal(resolved, true);
+});
+
+test("disposing resolves pending work and leaves the gate non-scrolling", async () => {
+  const windowLike = fakeWindow();
+  const gate = createScrollIdleGate({ windowLike });
+  gate.markScroll();
+  const pending = gate.wait();
+  gate.dispose();
+  await pending;
+  assert.equal(gate.isScrolling(), false);
+  assert.equal(windowLike.pendingIdle(), 0);
+});

--- a/tests/dashboard-scroll-stability.test.mjs
+++ b/tests/dashboard-scroll-stability.test.mjs
@@ -1,0 +1,9 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldAdjustDashboardScrollPositionOnItemSizeChange } from "../src/dashboard/scrollStability.js";
+
+test("late virtual row measurements never rewrite the user's scroll offset", () => {
+  assert.equal(shouldAdjustDashboardScrollPositionOnItemSizeChange({}, 24, {}), false);
+  assert.equal(shouldAdjustDashboardScrollPositionOnItemSizeChange({}, -18, {}), false);
+});

--- a/tests/dashboard-warmup.test.mjs
+++ b/tests/dashboard-warmup.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { scheduleDashboardWarmup } from "../src/core/dashboard-warmup.js";
+
+test("dashboard warm-up uses an idle slice and loads once", async () => {
+  let idleCallback = null;
+  let calls = 0;
+  const windowLike = {
+    requestIdleCallback(callback, options) {
+      assert.equal(options.timeout, 4000);
+      idleCallback = callback;
+      return 7;
+    },
+    cancelIdleCallback() {},
+  };
+  const dispose = scheduleDashboardWarmup({
+    isOpen: () => false,
+    ensureInitialLoad: async () => { calls += 1; },
+  }, { windowLike });
+
+  assert.equal(calls, 0);
+  idleCallback();
+  await Promise.resolve();
+  assert.equal(calls, 1);
+  dispose();
+});
+
+test("dashboard warm-up is cancelled during unload", () => {
+  let idleCallback = null;
+  let cancelled = null;
+  let calls = 0;
+  const windowLike = {
+    requestIdleCallback(callback) { idleCallback = callback; return 19; },
+    cancelIdleCallback(id) { cancelled = id; },
+  };
+  const dispose = scheduleDashboardWarmup({
+    ensureInitialLoad: () => { calls += 1; },
+  }, { windowLike });
+
+  dispose();
+  idleCallback();
+  assert.equal(cancelled, 19);
+  assert.equal(calls, 0);
+});
+
+test("dashboard warm-up does not compete with an already open dashboard", () => {
+  let idleCallback = null;
+  let calls = 0;
+  const windowLike = {
+    requestIdleCallback(callback) { idleCallback = callback; return 1; },
+    cancelIdleCallback() {},
+  };
+  scheduleDashboardWarmup({
+    isOpen: () => true,
+    ensureInitialLoad: () => { calls += 1; },
+  }, { windowLike });
+
+  idleCallback();
+  assert.equal(calls, 0);
+});

--- a/tests/dashboard-warmup.test.mjs
+++ b/tests/dashboard-warmup.test.mjs
@@ -59,3 +59,26 @@ test("dashboard warm-up does not compete with an already open dashboard", () => 
   idleCallback();
   assert.equal(calls, 0);
 });
+
+test("dashboard warm-up primes Analytics after the shared model is ready", async () => {
+  let idleCallback = null;
+  const events = [];
+  const windowLike = {
+    requestIdleCallback(callback) { idleCallback = callback; return 4; },
+    cancelIdleCallback() {},
+  };
+  scheduleDashboardWarmup({
+    isOpen: () => false,
+    ensureInitialLoad: async () => { events.push("model"); },
+    warmAnalyticsCache: async ({ yieldToMainThread, isCancelled }) => {
+      events.push("analytics");
+      assert.equal(typeof yieldToMainThread, "function");
+      assert.equal(isCancelled(), false);
+    },
+  }, { windowLike });
+
+  idleCallback();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(events, ["model", "analytics"]);
+});

--- a/tests/direct-parent.test.mjs
+++ b/tests/direct-parent.test.mjs
@@ -1,0 +1,11 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildDirectParentUidQuery } from "../src/core/direct-parent.js";
+
+test("child attribute sync queries the immediate parent relation", () => {
+  const query = buildDirectParentUidQuery("child-uid");
+
+  assert.match(query, /\[\?p :block\/children \?c\]/);
+  assert.doesNotMatch(query, /:block\/parents/);
+  assert.match(query, /\[\?c :block\/uid "child-uid"\]/);
+});

--- a/tests/filters.test.mjs
+++ b/tests/filters.test.mjs
@@ -215,6 +215,16 @@ test("query searches title, pageTitle and text, case-insensitively", () => {
   assert.deepEqual(uids([t], {}, ""), ["t"], "empty query does not filter");
 });
 
+test("query searches resolved block-reference titles", () => {
+  const t = task({
+    uid: "t",
+    title: "((xJuYmHX0v))",
+    text: "{{[[TODO]]}} ((xJuYmHX0v))",
+    displayTitle: "Commit the dashboard performance changes",
+  });
+  assert.deepEqual(uids([t], {}, "performance"), ["t"]);
+});
+
 test("query tolerates a missing pageTitle", () => {
   const t = task({ uid: "t", pageTitle: null, title: "Alpha" });
   assert.deepEqual(uids([t], {}, "alpha"), ["t"]);

--- a/tests/open-settings.test.mjs
+++ b/tests/open-settings.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  findBetterTasksSettingsTab,
+  openBetterTasksSettings,
+  selectBetterTasksSettingsTab,
+} from "../src/core/open-settings.js";
+
+function tab(text) {
+  return {
+    textContent: text,
+    clicks: 0,
+    click() { this.clicks += 1; },
+  };
+}
+
+test("developer settings tab wins when release and fork are both installed", () => {
+  const release = tab("Better Tasks");
+  const developer = tab("Better Tasks (dev)");
+  const documentLike = { querySelectorAll: () => [release, developer] };
+
+  assert.equal(findBetterTasksSettingsTab(documentLike), developer);
+  assert.equal(selectBetterTasksSettingsTab(documentLike), true);
+  assert.equal(developer.clicks, 1);
+  assert.equal(release.clicks, 0);
+});
+
+test("settings opener launches Roam Depot and selects the asynchronously mounted tab", async () => {
+  const developer = tab("Better Tasks (dev)");
+  let depotClicks = 0;
+  let polls = 0;
+  const documentLike = {
+    querySelector(selector) {
+      if (selector === ".rm-left-sidebar__roam-depot") {
+        return { click() { depotClicks += 1; } };
+      }
+      return null;
+    },
+    querySelectorAll() {
+      polls += 1;
+      return polls >= 3 ? [developer] : [];
+    },
+  };
+
+  const opened = await openBetterTasksSettings({
+    documentLike,
+    wait: async () => {},
+    attempts: 4,
+  });
+  assert.equal(opened, true);
+  assert.equal(depotClicks, 1);
+  assert.equal(developer.clicks, 1);
+});
+
+test("settings opener fails cleanly when Roam Depot is unavailable", async () => {
+  const documentLike = {
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+  const opened = await openBetterTasksSettings({ documentLike, roamAlphaAPI: null });
+  assert.equal(opened, false);
+});

--- a/tests/suggestion-snapshot.test.mjs
+++ b/tests/suggestion-snapshot.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  readSuggestionCountSnapshot,
+  suggestionCountSnapshotKey,
+  writeSuggestionCountSnapshot,
+} from "../src/core/suggestion-snapshot.js";
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    values,
+  };
+}
+
+test("suggestion count snapshot round-trips per graph", () => {
+  const storage = memoryStorage();
+  const key = suggestionCountSnapshotKey("Svy graph");
+  writeSuggestionCountSnapshot(storage, key, 6, { now: 1000 });
+  assert.deepEqual(readSuggestionCountSnapshot(storage, key, { now: 1200 }), {
+    count: 6,
+    computedAt: 1000,
+  });
+  assert.match(key, /Svy%20graph/);
+});
+
+test("suggestion count snapshot rejects stale or malformed values", () => {
+  const storage = memoryStorage();
+  const key = suggestionCountSnapshotKey("Svy");
+  storage.setItem(key, JSON.stringify({ schema: 1, count: 6, computedAt: 1000 }));
+  assert.equal(readSuggestionCountSnapshot(storage, key, { now: 5000, maxAgeMs: 1000 }), null);
+  storage.setItem(key, JSON.stringify({ schema: 1, count: -1, computedAt: 5000 }));
+  assert.equal(readSuggestionCountSnapshot(storage, key, { now: 5000 }), null);
+  storage.setItem(key, "not-json");
+  assert.equal(readSuggestionCountSnapshot(storage, key, { now: 5000 }), null);
+});

--- a/tests/theme-observer.test.mjs
+++ b/tests/theme-observer.test.mjs
@@ -1,0 +1,104 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getThemeObserverRegistrations } from "../src/core/theme-observer.js";
+
+// A tiny stand-in for the browser's MutationObserver that honours the one
+// piece of its contract this suite cares about: whether an attribute
+// mutation on a given node is delivered to the callback, based on the
+// registered target, `subtree`, and `attributeFilter` - exactly the
+// dimensions Better Tasks' theme observer configures.
+function isDescendantOf(node, ancestor) {
+  let cur = node.parentNode;
+  while (cur) {
+    if (cur === ancestor) return true;
+    cur = cur.parentNode;
+  }
+  return false;
+}
+
+class FakeMutationObserver {
+  constructor(callback) {
+    this.callback = callback;
+    this.registrations = [];
+  }
+  observe(target, options) {
+    this.registrations.push({ target, options });
+  }
+  // Test helper only - simulates the browser deciding whether a mutation
+  // on `node` matches any registration and, if so, invoking the callback.
+  simulateAttributeMutation(node, attributeName) {
+    for (const { target, options } of this.registrations) {
+      if (!options.attributes) continue;
+      if (options.attributeFilter && !options.attributeFilter.includes(attributeName)) continue;
+      const matches = node === target || (options.subtree && isDescendantOf(node, target));
+      if (matches) {
+        this.callback();
+        return;
+      }
+    }
+  }
+}
+
+function makeNode(parentNode = null) {
+  return { parentNode };
+}
+
+function buildDocumentTree() {
+  const documentElement = makeNode();
+  const body = makeNode(documentElement);
+  // Mirrors Roam's own structure: a block container deep under <body> that
+  // gets its `class` toggled by Roam's own render as the user types.
+  const blockContainer = makeNode(body);
+  const blockMain = makeNode(blockContainer);
+  const head = makeNode(documentElement);
+  const themeLink = makeNode(head);
+  return { documentElement, body, blockContainer, blockMain, head, themeLink };
+}
+
+function attachFakeObserver(tree) {
+  let calls = 0;
+  const observer = new FakeMutationObserver(() => {
+    calls += 1;
+  });
+  for (const { target, options } of getThemeObserverRegistrations(tree)) {
+    observer.observe(target, options);
+  }
+  return { observer, getCalls: () => calls };
+}
+
+test("typing inside a block (a nested class mutation) never reaches the theme observer", () => {
+  const tree = buildDocumentTree();
+  const { observer, getCalls } = attachFakeObserver(tree);
+
+  // This is what Roam does on nearly every keystroke: toggle a class deep
+  // inside body/documentElement's subtree. It must not trigger a resync.
+  observer.simulateAttributeMutation(tree.blockMain, "class");
+  assert.equal(getCalls(), 0, "a descendant class mutation must not reach the theme observer");
+});
+
+test("a real theme change on body or documentElement itself still resyncs", () => {
+  const tree = buildDocumentTree();
+  const { observer, getCalls } = attachFakeObserver(tree);
+
+  observer.simulateAttributeMutation(tree.body, "class");
+  observer.simulateAttributeMutation(tree.documentElement, "data-theme");
+  assert.equal(getCalls(), 2, "class/data-theme changes on body or documentElement must still resync");
+});
+
+test("document.head keeps subtree tracking so injected stylesheet swaps still resync", () => {
+  const tree = buildDocumentTree();
+  const { observer, getCalls } = attachFakeObserver(tree);
+
+  observer.simulateAttributeMutation(tree.themeLink, "href");
+  assert.equal(getCalls(), 1, "a stylesheet link swap nested under <head> must still resync");
+});
+
+test("body/documentElement registrations do not request subtree observation", () => {
+  const tree = buildDocumentTree();
+  const registrations = getThemeObserverRegistrations(tree);
+  const byTarget = new Map(registrations.map((r) => [r.target, r.options]));
+
+  assert.equal(byTarget.get(tree.body).subtree, false);
+  assert.equal(byTarget.get(tree.documentElement).subtree, false);
+  assert.equal(byTarget.get(tree.head).subtree, true);
+});


### PR DESCRIPTION
## Correction (2026-08-06) — please read before reviewing the perf claims

**Better Tasks is not the source of the per-keystroke long tasks described below. A
different extension is, and it is not part of this repository.**

This description previously withdrew a specific latency *number* (see "Measured"). The
underlying *premise* was also wrong and is withdrawn now: the statement that "the extension
was still adding roughly one browser long task per keystroke" was a misattribution.

Re-measured on the same 101k-block encrypted graph, scratch page created and deleted per
arm, 40 synthetic keystrokes, **every arm asserting its own precondition** (a runtime global
proving the extension did or did not load), n=2 per arm:

| arm | long tasks per 40 keystrokes |
|---|---|
| all developer extensions blocked | 0, 0 |
| all loaded (control) | 40, 40 |
| **block only `roam-auto-attribute`** (Better Tasks still loaded) | **1, 1** |
| block only Better Tasks | 40 |

The jank is owned by `roam-auto-attribute`, a personal extension of mine that is unrelated
to Better Tasks. With it blocked and Better Tasks fully loaded, long tasks drop from 40 to
1. **No change to this repository was ever going to fix it.**

Why the original bisection went wrong: it was n=1 on a metric I had already recorded as
varying 40 / 23 / 15 between runs, and the "Better Tasks blocked" arm most likely used a URL
pattern broad enough to also block my other similarly-hosted extensions. A second error
compounded it — the profiling harness attributed CPU with
`if (url.includes("roamresearch.com")) owner = "roam-core"`, but Roam serves every extension
from `blob:https://roamresearch.com/<uuid>`, so all extension CPU was filed under Roam core.

**Consequently, the two follow-up suspects listed at the bottom of this description are not
implicated by measurement and I would not spend time on them:** `decorateBlockPills`' layout
read/write cycle and the `getBlock()` cache-busting fan-out. Directly tested this session,
with Better Tasks loaded: removing all pull watches changed nothing (40 → 40), disabling 81
of 82 injected stylesheets changed nothing (40 → 40), and Better Tasks' own sampled CPU
across 40 keystrokes was 2–20 ms. Its Today panel did not rebuild once across 89 keystrokes.

## What still stands in this PR

The theme-observer change is defensible on inspection independent of any latency claim:
`syncDashboardThemeVars` reads `body.classList` and `root.classList` directly and never
inspects a descendant, so `subtree: true` on `body`/`documentElement` genuinely buys nothing
and only creates `MutationRecord` bookkeeping. Treat it as a correctness/tidiness change, not
a performance fix. The dashboard idle-warm, caching and virtualization work rests on its own
separate first-scroll measurements (35.6 ms p95 → 15.1 ms p95), which are unaffected by any
of the above.

---

## What changed

Normal Roam typing was still entering the Better Tasks input handler and could trigger attribute parsing or graph reads. This branch exits early for plain text and only does the extra work when an edit looks like a Better Tasks attribute.

The dashboard now prepares its shared task model during idle time. Suggestions and Analytics reuse that model and cache their results by graph. Their background refreshes pause while the user is scrolling.

Virtualized rows use content-based height estimates, and late measurements no longer change the user's scroll position. This removes the initial scroll hitch and the occasional snap after scrolling stops.

This branch also:

- resolves `((block refs))` in task titles
- syncs child attributes only to the direct task parent
- adds a Settings button and command
- wraps dashboard text and controls in narrow panels

## Theme observer no longer watches the whole document

The dashboard work above only helps while the dashboard is open. Measuring an ordinary
typing session afterwards showed the extension was still adding roughly **one browser long
task per keystroke** on a page with no dashboard and no tasks on screen, so there was a
second, always-on cause.

`observeThemeChanges()` runs unconditionally at load and registered its `MutationObserver`
on `document.body` and `document.documentElement` with `subtree: true`. Roam changes classes
on nearly every keystroke — decorations, caret and focus state, virtualized rows — and each
of those mutations had to be materialized into a `MutationRecord` for this extension.

Two things made that expensive and easy to miss:

- The bookkeeping is charged to whichever script performs the DOM write, which is Roam's own
  render task. The cost therefore does not show up as this extension's CPU time in a profile.
- `subtree: true` bought nothing. The only reader driven by this observer,
  `syncDashboardThemeVars`, inspects `body.classList` and `root.classList` directly and never
  looks at a descendant. The two cases that genuinely need a deep target — the Roam Studio and
  Blueprint toggle buttons — already have their own narrowly scoped observer and click listener.

The registration logic moved into `src/core/theme-observer.js` so it can be tested, and
`body` / `documentElement` are now observed without `subtree`. `document.head` keeps subtree
tracking, since theme extensions swap `<link>` and `<style>` tags there and head does not
mutate while someone is typing.

## Measured

**Correction (2026-08-05): an earlier version of this description claimed this commit took
long tasks from ~40 to 1 per 40 keystrokes. That measurement was invalid and the claim is
withdrawn.**

The A/B served the rebuilt bundle in place of the installed one via Chrome DevTools
Protocol request interception. Interception turns out to suppress the extension itself, so
the "after" arm was measuring Better Tasks *not running* rather than Better Tasks running
with this change. The giveaway was in the numbers and I missed it: the "after" arm landed
on 48.8 ms / 1 long task, which matched *extension absent entirely* (48.6 ms / 1) almost
exactly — a change that removes one observer should not reproduce the absent case.

Re-measured with the built bundle actually installed and loading normally, on the same
101k-block graph, 40 synthetic keystrokes into a freshly created empty page:

| build | long tasks per 40 keystrokes | mean keystroke → paint |
|---|---|---|
| before this commit | 40, 23, 15 (3 runs) | 57.3 / 52.0 / 51.5 ms |
| after this commit, installed normally | 40, 40, 40 (3 runs) | 58.2 / 58.4 / 57.7 ms |
| same bundle via CDP interception (invalid method) | 1, 1, 1 | 48.8 / 49.2 / 47.8 ms |

So **this commit does not measurably reduce per-keystroke long tasks.** What remains true
on inspection is that `subtree: true` on `document.body` and `document.documentElement`
buys nothing here — `syncDashboardThemeVars` reads `body.classList` and `root.classList`
directly and never a descendant, and the deep-target cases have their own scoped observers.
Narrowing it is defensible on its own terms, and it is a small, contained change. But I
cannot claim a latency win for it, and the source of the remaining long tasks is still
unidentified.

Take this commit as a scope correction, not a performance fix. Happy to drop it from the
branch if you would rather keep this PR to the dashboard work that does have measurements
behind it.

## Not addressed here

Two further always-on costs are visible in the source but were out of scope for this branch,
because they only engage on pages that actually have blocks to decorate and I could not build
a regression test for them without a populated live graph:

- `decorateBlockPills` interleaves `getBoundingClientRect`, pill removal, `getComputedStyle`
  and `offsetHeight` per candidate node, which is a read/write layout cycle per block.
- The same loop calls `getBlock()` per visible block and per child TODO; the child fan-out
  invalidates the 800 ms block cache immediately before reading, so those datalog queries run
  on every pass.

Happy to look at either in a follow-up if you'd like.

## Checks

- strict i18n parity passed
- all 287 tests pass (283 existing + 4 new in `tests/theme-observer.test.mjs`)
- production webpack build passes
- the new test fails when `subtree: true` is restored — 2 of its 4 assertions fail, including
  the behavioural one that a nested class mutation must not reach the observer callback
- cold dashboard opening and Analytics switching tested in Roam
- live 90-frame first-scroll trace improved from 35.6 ms p95 to 15.1 ms p95, with no frames over 20 ms

