### PR TITLE
Fix invisible Today panel text and buttons in dark mode

### DIFF
--- a/extension.css
+++ b/extension.css
@@ -501,6 +501,32 @@ body.bt-theme-dark .bt-today-panel__icon-btn:focus-visible {
     outline-color: #63b3ed;
 }
 
+/* Roam core (assets/css/less-compiled/site.css) ships
+       .bp3-dark button { color: var(--dark-bg); }
+   at specificity 0,1,1. A bare `.bt-today-panel__row-title { color: inherit }`
+   is only 0,1,0, so Roam wins and paints the task title with the panel
+   BACKGROUND colour — measured contrast 1.00, i.e. invisible. The icon buttons
+   escaped this only because their dark rule above is 0,2,0.
+
+   So: every <button> the panel renders needs an explicit colour at >= 0,1,1.
+   Scope it to the panel root and match `button` directly (0,2,2) so any button
+   added later inherits the fix instead of silently disappearing. Disabled state
+   above stays 0,3,0 and still wins.
+
+   Note `body.bp3-dark` alone is NOT sufficient: in this Roam build `bp3-dark`
+   lives on <html>, and in Roam's auto mode it exists nowhere at all — hence the
+   :is(html, body) form plus the prefers-color-scheme fallback. */
+body.bt-theme-dark .bt-today-panel-root button,
+:is(html, body).bp3-dark .bt-today-panel-root button {
+    color: rgba(247, 249, 251, 0.92);
+}
+
+@media (prefers-color-scheme: dark) {
+    body:not(.bt-theme-light) .bt-today-panel-root button {
+        color: rgba(247, 249, 251, 0.92);
+    }
+}
+
 .bt-today-badge {
     display: flex;
     align-items: center;

--- a/extension.css
+++ b/extension.css
@@ -4754,6 +4754,15 @@ body.bt-theme-dark .bt-kb-help-footer kbd {
     background: rgba(0, 0, 0, 0.25);
 }
 
+/* Matches the dark scrim the series and activity overlays already use — a 25%
+   black wash over an already-dark page barely separates the panel from what is
+   behind it. */
+body.bp3-dark .bt-analytics-overlay__backdrop,
+body.bt-theme-dark .bt-analytics-overlay__backdrop,
+:is(html, body).bp3-dark .bt-analytics-overlay__backdrop {
+    background: rgba(0, 0, 0, 0.45);
+}
+
 .bt-analytics-overlay__panel {
     position: relative;
     width: 480px;
@@ -4787,6 +4796,18 @@ body.bt-theme-dark .bt-kb-help-footer kbd {
     margin: 0;
 }
 
+/* The overlay's close ✕ is a bare `.bp3-button.bp3-minimal`. Blueprint's own
+   `.bp3-dark .bp3-button` (0,2,0) covers it only while Roam actually carries
+   bp3-dark; when the panel resolves dark from a sampled background or the
+   external appearance toggle (body.bt-theme-dark, bp3-dark nowhere) the
+   light-theme Blueprint ink renders on a dark panel. Same treatment
+   .bt-dashboard__header-actions .bp3-button already gets, at 0,3,0. */
+body.bp3-dark .bt-analytics-header .bp3-button,
+body.bt-theme-dark .bt-analytics-header .bp3-button,
+:is(html, body).bp3-dark .bt-analytics-header .bp3-button {
+    color: var(--bt-panel-text, rgba(247, 249, 251, 0.92));
+}
+
 .bt-analytics-periods {
     display: flex;
     gap: 4px;
@@ -4808,6 +4829,47 @@ body.bt-theme-dark .bt-kb-help-footer kbd {
     background: var(--bt-chart-bar);
     color: #fff;
     border-color: var(--bt-chart-bar);
+}
+
+/* Both period chips are <button>s and both base rules above are 0,1,0. Roam
+   core ships `.bp3-dark button { color: var(--dark-bg) }` at 0,1,1, so in dark
+   mode Roam wins and paints every chip label with the page BACKGROUND colour —
+   the same invisible-text trap already documented for the Today panel and the
+   filter chips. `background: none` on an inactive chip resolves to the dark
+   panel beneath it, so its label vanished outright; the active chip stayed
+   readable only by accident, because Roam's dark ink happens to land on a
+   light-blue fill.
+
+   These rules are 0,2,1 and win. `:is(html, body).bp3-dark` matches this Roam
+   build, where bp3-dark lives on <html> so the plain `body.bp3-dark` form never
+   fires; same 0,2,1 specificity as the body form beside it. */
+body.bp3-dark .bt-analytics-period-btn,
+body.bt-theme-dark .bt-analytics-period-btn,
+:is(html, body).bp3-dark .bt-analytics-period-btn {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--bt-panel-text, rgba(247, 249, 251, 0.92));
+    border-color: var(--bt-border-strong, rgba(255, 255, 255, 0.32));
+}
+
+/* `:not(--active)` keeps hover disjoint from the active rule below instead of
+   out-specifying it, so source order between the two stops mattering. */
+body.bp3-dark .bt-analytics-period-btn:not(.bt-analytics-period-btn--active):hover,
+body.bt-theme-dark .bt-analytics-period-btn:not(.bt-analytics-period-btn--active):hover,
+:is(html, body).bp3-dark .bt-analytics-period-btn:not(.bt-analytics-period-btn--active):hover {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: var(--bt-border-strong, rgba(255, 255, 255, 0.4));
+}
+
+/* The active chip's fill is --bt-chart-bar, which the dark token block sets to
+   #60a5fa. Pinning the base rule's `#fff` here would put white on light blue —
+   2.6:1, below WCAG AA — and would be a regression against what renders today,
+   since Roam's rule is currently painting dark ink there. Keep dark ink. */
+body.bp3-dark .bt-analytics-period-btn--active,
+body.bt-theme-dark .bt-analytics-period-btn--active,
+:is(html, body).bp3-dark .bt-analytics-period-btn--active {
+    background: var(--bt-chart-bar, #60a5fa);
+    color: #0f1418;
+    border-color: var(--bt-chart-bar, #60a5fa);
 }
 
 .bt-analytics-content {

--- a/extension.css
+++ b/extension.css
@@ -458,6 +458,24 @@ body.bt-theme-dark .bt-task-row__context {
     color: var(--bt-muted);
 }
 
+/* Today panel. Its own styles inherit colour from the host block and read
+   --bt-panel-text, both of which can resolve to a light-theme value (Roam
+   leaves --bp3-text-color at #202B33 under .bp3-dark), leaving invisible
+   titles and ghost icon buttons. Pin literal light values here, like the
+   task-row rules above, rather than routing through the sampled variable. */
+body.bp3-dark .bt-today-panel-root,
+body.bt-theme-dark .bt-today-panel-root {
+    color: rgba(247, 249, 251, 0.92);
+}
+
+body.bp3-dark .bt-today-panel__icon-btn,
+body.bt-theme-dark .bt-today-panel__icon-btn {
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(247, 249, 251, 0.92);
+    border-color: rgba(255, 255, 255, 0.28);
+    box-shadow: none;
+}
+
 .bt-today-badge {
     display: flex;
     align-items: center;

--- a/extension.css
+++ b/extension.css
@@ -428,17 +428,52 @@ body.bt-theme-dark .bt-task-row__page-ref--plain {
     background: rgba(255, 255, 255, 0.1);
 }
 
+/* Filter chips and task pills are both <button>s whose base rules
+   (`.bt-chip`, `.bt-pill`) are 0,1,0 — under the `.bp3-dark button { color:
+   var(--dark-bg) }` rule Roam ships at 0,1,1 their label is painted with the
+   page BACKGROUND colour, the same invisible-text trap documented for the
+   Today panel below. These rules are 0,2,1 and win.
+
+   `.bt-chip` also had no dark background at all: `background: transparent` plus
+   a 1px translucent border reads as an empty outline on a dark panel, and
+   `.bt-pill` had no dark rule whatsoever. Give the inactive states a real
+   surface. `:is(html, body).bp3-dark` matches this Roam build, where bp3-dark
+   lives on <html> so the `body.bp3-dark` form never fires; it has the same
+   0,2,1 specificity as the body form it sits beside. */
 body.bp3-dark .bt-chip,
-body.bt-theme-dark .bt-chip {
-    color: var(--bt-panel-text);
-    border-color: rgba(255, 255, 255, 0.32);
+body.bt-theme-dark .bt-chip,
+:is(html, body).bp3-dark .bt-chip {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--bt-panel-text, rgba(247, 249, 251, 0.92));
+    border-color: var(--bt-border-strong, rgba(255, 255, 255, 0.32));
 }
 
 body.bp3-dark .bt-chip--active,
-body.bt-theme-dark .bt-chip--active {
-    background: var(--bt-panel-text);
+body.bt-theme-dark .bt-chip--active,
+:is(html, body).bp3-dark .bt-chip--active {
+    background: var(--bt-panel-text, rgba(247, 249, 251, 0.92));
     color: #0f1418;
-    border-color: var(--bt-panel-text);
+    border-color: var(--bt-panel-text, rgba(247, 249, 251, 0.92));
+}
+
+body.bp3-dark .bt-pill,
+body.bt-theme-dark .bt-pill,
+:is(html, body).bp3-dark .bt-pill {
+    background: var(--bt-pill-bg, rgba(255, 255, 255, 0.12));
+    color: var(--bt-panel-text, rgba(247, 249, 251, 0.92));
+    border-color: var(--bt-border-strong, rgba(255, 255, 255, 0.28));
+}
+
+/* `.bt-pill--muted { opacity: .6 }` multiplies against text that is already
+   alpha'd, which is how the disabled Today-panel buttons ended up illegible.
+   Dim with an explicit colour instead and keep the pill body visible. */
+body.bp3-dark .bt-pill--muted,
+body.bt-theme-dark .bt-pill--muted,
+:is(html, body).bp3-dark .bt-pill--muted {
+    opacity: 1;
+    background: rgba(255, 255, 255, 0.07);
+    color: rgba(247, 249, 251, 0.68);
+    border-color: rgba(255, 255, 255, 0.2);
 }
 
 body.bp3-dark .bt-filter-row__label,

--- a/extension.css
+++ b/extension.css
@@ -476,6 +476,31 @@ body.bt-theme-dark .bt-today-panel__icon-btn {
     box-shadow: none;
 }
 
+body.bp3-dark .bt-today-panel__icon-btn:hover,
+body.bt-theme-dark .bt-today-panel__icon-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.4);
+}
+
+/* disableAll() sets .disabled while an action is in flight; the pinned
+   dark `color` above is an author-level override that beats the
+   button:disabled user-agent grey, so give disabled state its own
+   explicit (dimmer) values instead of leaning on opacity, which would
+   multiply against the already-alpha'd text and land back in the same
+   low-contrast trap as the blocked/completed rows below. */
+body.bp3-dark .bt-today-panel__icon-btn:disabled,
+body.bt-theme-dark .bt-today-panel__icon-btn:disabled {
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(247, 249, 251, 0.45);
+    border-color: rgba(255, 255, 255, 0.14);
+    cursor: not-allowed;
+}
+
+body.bp3-dark .bt-today-panel__icon-btn:focus-visible,
+body.bt-theme-dark .bt-today-panel__icon-btn:focus-visible {
+    outline-color: #63b3ed;
+}
+
 .bt-today-badge {
     display: flex;
     align-items: center;
@@ -514,6 +539,16 @@ body.bt-theme-dark .bt-today-panel__icon-btn {
     font-size: 16px;
     font-weight: 500;
     line-height: 24px;
+}
+
+body.bp3-dark .bt-today-badge:hover,
+body.bt-theme-dark .bt-today-badge:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+body.bp3-dark .bt-today-badge__icon,
+body.bt-theme-dark .bt-today-badge__icon {
+    color: rgba(247, 249, 251, 0.78);
 }
 
 body.bp3-dark .bt-task-row__actions .bp3-button,

--- a/src/core/theme-resolve.js
+++ b/src/core/theme-resolve.js
@@ -1,0 +1,29 @@
+// Pure decision for whether the dashboard / Today panel should render dark.
+//
+// Precedence:
+//   1. A theme extension's own appearance toggle (Roam Studio / Blueprint)
+//      set explicitly to light or dark — the user chose that mode.
+//   2. Roam's `bp3-dark` class or `data-theme="dark"` marker.
+//   3. The measured luminance of Roam's rendered background. This is the
+//      ground truth for what the user is looking at, and it must outrank the
+//      OS hint: macOS in dark mode with Roam in its default light theme used
+//      to fall through to `prefers-color-scheme` and resolve dark, which
+//      tagged `body.bt-theme-dark` and painted the Today panel's pinned
+//      near-white dark-mode text onto the white page.
+//   4. The OS `prefers-color-scheme` hint, only when nothing above is
+//      available (e.g. Roam's chrome isn't mounted yet, so there is no
+//      background to sample).
+export function resolvePanelIsDark({
+  externalMode = null,
+  explicitDark = false,
+  sampledLuminance = null,
+  systemPrefersDark = false,
+} = {}) {
+  if (externalMode === "dark") return true;
+  if (externalMode === "light") return false;
+  if (explicitDark) return true;
+  if (typeof sampledLuminance === "number" && !Number.isNaN(sampledLuminance)) {
+    return sampledLuminance < 0.5;
+  }
+  return !!systemPrefersDark;
+}

--- a/src/core/theme-resolve.js
+++ b/src/core/theme-resolve.js
@@ -27,3 +27,32 @@ export function resolvePanelIsDark({
   }
   return !!systemPrefersDark;
 }
+
+// Whether syncDashboardThemeVars should skip re-writing the panel's custom
+// properties given the last cached sample.
+//
+// The "nothing changed" check used to compare the sampled panel-surface
+// colour alone. That sample is built from incidental candidates (Roam/
+// Blueprint custom properties that may not exist yet, a background-color
+// walk that can legitimately return the same string on two different ticks)
+// and is NOT guaranteed to move in lockstep with the resolved light/dark
+// mode — most visibly right after a theme-observer class mutation, where
+// Roam's own dark class flips correctly but the surface-colour heuristic
+// still reports the pre-flip value on that pass. Keying the skip decision
+// on surface alone let a genuine dark<->light transition get silently
+// dropped: the function returned early before ever reaching the
+// classList.toggle("bt-theme-dark", ...) call or the six custom-property
+// writes, so the panel stayed stuck on its last-written mode.
+//
+// Require the resolved MODE to also be unchanged before skipping, so any
+// tick where finalIsDark differs from the last write always proceeds —
+// closing the class of bug regardless of why the surface sample happened
+// to look unchanged.
+export function shouldSkipThemeSync({
+  forced = false,
+  sameSurface = false,
+  sameMode = false,
+} = {}) {
+  if (forced) return false;
+  return sameSurface && sameMode;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,7 @@ import {
   formatContextListForWrite,
 } from "./core/page-refs";
 import { parseBtQuery, KNOWN_KEYS as BT_QUERY_KNOWN_KEYS } from "./core/bt-query-parser";
+import { resolvePanelIsDark } from "./core/theme-resolve.js";
 import {
   normalizePulledSubtree,
   flattenSubtreeToCreateSteps,
@@ -19714,16 +19715,6 @@ function syncDashboardThemeVars() {
     root.dataset.theme === "dark";
 
   const externalMode = getExternalAppearanceFromToggle(); // "dark" | "light" | "auto" | null
-  let finalIsDark;
-  if (externalMode === "dark") {
-    finalIsDark = true;
-  } else if (externalMode === "light") {
-    finalIsDark = false;
-  } else if (externalMode === "auto") {
-    finalIsDark = explicitDark || systemPrefersDark;
-  } else {
-    finalIsDark = explicitDark || systemPrefersDark;
-  }
 
   const layoutBg = sampleBackgroundColor([
     ".roam-main",
@@ -19731,6 +19722,13 @@ function syncDashboardThemeVars() {
     ".roam-body",
     "#app",
   ]);
+
+  const finalIsDark = resolvePanelIsDark({
+    externalMode,
+    explicitDark,
+    sampledLuminance: computeLuminance(parseColorToRgb(layoutBg)),
+    systemPrefersDark,
+  });
 
   // Theme-specific dark fallback for the panel surface
   const darkFallbackSurface = usingBlueprint ? "#202B33" : "#1f2428";

--- a/src/index.js
+++ b/src/index.js
@@ -19726,7 +19726,12 @@ function syncDashboardThemeVars() {
   const finalIsDark = resolvePanelIsDark({
     externalMode,
     explicitDark,
-    sampledLuminance: computeLuminance(parseColorToRgb(layoutBg)),
+    sampledLuminance: computeLuminance(
+      parseColorToRgb(
+        layoutBg ||
+          sampleEffectiveBackgroundColor([".roam-main", ".roam-article", "#app", "body"])
+      )
+    ),
     systemPrefersDark,
   });
 
@@ -19926,6 +19931,26 @@ function sampleBackgroundColor(selectors = []) {
     const color = style?.backgroundColor;
     if (color && color !== "rgba(0, 0, 0, 0)" && color !== "transparent") {
       return color;
+    }
+  }
+  return null;
+}
+
+// Roam paints the page background on <body> (desktop wraps it once more in
+// .rm-electron); .roam-main, .roam-article and every container between them
+// are fully transparent. Sampling only the selectors themselves therefore
+// returns null and the theme decision would fall through to the OS hint —
+// walk each candidate's ancestor chain until something actually paints.
+function sampleEffectiveBackgroundColor(selectors = []) {
+  if (typeof document === "undefined") return null;
+  for (const selector of selectors) {
+    let node = typeof selector === "string" ? document.querySelector(selector) : selector;
+    while (node) {
+      const color = window.getComputedStyle(node)?.backgroundColor;
+      if (color && color !== "rgba(0, 0, 0, 0)" && color !== "transparent") {
+        return color;
+      }
+      node = node.parentElement;
     }
   }
   return null;

--- a/src/index.js
+++ b/src/index.js
@@ -19777,49 +19777,98 @@ function syncDashboardThemeVars() {
   const fallbackMutedDark = usingBlueprint
     ? "rgba(255,255,255,0.82)"
     : "rgba(255,255,255,0.65)";
+  // Non-Blueprint value tracks the stylesheet's own dark --bt-pill-bg: this is
+  // now the authoritative source for that variable, so anything lower would
+  // make pills fainter in dark themes than they were before the cascade fix.
   const fallbackPillBgDark = usingBlueprint
     ? "rgba(255,255,255,0.18)"
-    : "rgba(255,255,255,0.08)";
+    : "rgba(255,255,255,0.12)";
 
-  const textColor = pickColorValue(
-    finalIsDark ? fallbackTextDark : "#111111",
-    computed.getPropertyValue("--bt-text"),
-    computed.getPropertyValue("--bp3-text-color"),
-    computed.color
+  // A sample only helps if it agrees with the mode we resolved. Roam keeps
+  // --bp3-text-color at #202B33 under .bp3-dark, and --bp3-border-color at its
+  // light-mode ink, so these chains can hand back a light-theme colour while we
+  // are painting a dark panel. That never showed while these writes landed on
+  // <html>, because the stylesheet's `body.bt-theme-dark` block shadowed them;
+  // now that they land on <body> and actually win (see the writes below), an
+  // unchecked sample would paint dark-on-dark. Reject a dark sample in dark mode
+  // and keep the pinned fallback — the same clamp the panel surface already got
+  // above. Light mode is deliberately left alone: its writes were never
+  // shadowed, so its sampling is the behaviour already shipping.
+  const darkSafe = (value, fallback) => {
+    if (!finalIsDark) return value;
+    const luminance = computeLuminance(parseColorToRgb(value));
+    return typeof luminance === "number" && luminance >= 0.5 ? value : fallback;
+  };
+
+  const textColor = darkSafe(
+    pickColorValue(
+      finalIsDark ? fallbackTextDark : "#111111",
+      computed.getPropertyValue("--bt-text"),
+      computed.getPropertyValue("--bp3-text-color"),
+      computed.color
+    ),
+    fallbackTextDark
   );
 
-  const borderColor = pickColorValue(
-    finalIsDark ? fallbackBorderDark : "rgba(0,0,0,0.08)",
-    computed.getPropertyValue("--bt-border-color"),
-    computed.getPropertyValue("--bp3-border-color"),
-    computed.getPropertyValue("--border-color")
+  const borderColor = darkSafe(
+    pickColorValue(
+      finalIsDark ? fallbackBorderDark : "rgba(0,0,0,0.08)",
+      computed.getPropertyValue("--bt-border-color"),
+      computed.getPropertyValue("--bp3-border-color"),
+      computed.getPropertyValue("--border-color")
+    ),
+    fallbackBorderDark
   );
 
-  const mutedColor = pickColorValue(
-    finalIsDark ? fallbackMutedDark : "rgba(0,0,0,0.6)",
-    computed.getPropertyValue("--bt-muted-color"),
-    computed.getPropertyValue("--text-color-muted")
+  const mutedColor = darkSafe(
+    pickColorValue(
+      finalIsDark ? fallbackMutedDark : "rgba(0,0,0,0.6)",
+      computed.getPropertyValue("--bt-muted-color"),
+      computed.getPropertyValue("--text-color-muted")
+    ),
+    fallbackMutedDark
   );
 
-  const pillBg = pickColorValue(
-    finalIsDark ? fallbackPillBgDark : "rgba(0,0,0,0.07)",
-    computed.getPropertyValue("--bt-pill-bg")
-  );
+  // Every other sample above reads a THEME-owned input variable (--bt-surface,
+  // --bt-text, --bt-border-color, --bt-muted-color) and writes a different,
+  // extension-owned output variable. --bt-pill-bg was the one name used as both
+  // input and output, so it never resolved to anything but the value the
+  // stylesheet had just declared — the theme-specific fallbacks below were dead.
+  // Reading it is also unsafe now that the write target is <body> (see below):
+  // the value written on a dark pass would be read back on the next light pass
+  // and pin dark pills onto a light panel.
+  const pillBg = finalIsDark ? fallbackPillBgDark : "rgba(0,0,0,0.07)";
 
   body.classList.toggle("bt-theme-dark", finalIsDark);
   body.classList.toggle("bt-theme-light", !finalIsDark);
 
   const adjustedPanel =
     adjustColor(panelRgb, finalIsDark ? -0.06 : 0.03) || baseSurface;
+  // adjustColor mixes toward white for a positive delta and toward black for a
+  // negative one, so a "strong" border has to move AWAY from the panel: lighter
+  // than a dark surface, darker than a light one. The old signs did the reverse
+  // and, on the default white panel, resolved --bt-border-strong to #ffffff —
+  // an invisible border, which is live today because only the dark half of
+  // these writes was being shadowed by the stylesheet.
   const borderStrong =
-    adjustColor(panelRgb, finalIsDark ? -0.22 : 0.15) || borderColor;
+    adjustColor(panelRgb, finalIsDark ? 0.22 : -0.15) || borderColor;
 
-  root.style.setProperty("--bt-panel-bg", adjustedPanel);
-  root.style.setProperty("--bt-panel-text", textColor);
-  root.style.setProperty("--bt-border", borderColor);
-  root.style.setProperty("--bt-border-strong", borderStrong);
-  root.style.setProperty("--bt-muted", mutedColor);
-  root.style.setProperty("--bt-pill-bg", pillBg);
+  // Write on <body>, not <html>. Custom properties resolve per element: the
+  // dark block in extension.css declares these same six names on
+  // `body.bt-theme-dark`, so <body> and every panel node under it took the
+  // stylesheet's value and the html-level inline declaration was only ever
+  // visible to <html> itself. Everything this function samples — the clamped
+  // #202B33 Blueprint surface, the stronger Blueprint borders/pills, the
+  // adjustColor() panel and border-strong shades — was therefore computed and
+  // then discarded. Inline style on <body> outranks that class rule, so the
+  // sampled values now reach the panel. The theme MutationObserver filters on
+  // ["class", "data-theme"], so writing style here cannot re-enter this sync.
+  body.style.setProperty("--bt-panel-bg", adjustedPanel);
+  body.style.setProperty("--bt-panel-text", textColor);
+  body.style.setProperty("--bt-border", borderColor);
+  body.style.setProperty("--bt-border-strong", borderStrong);
+  body.style.setProperty("--bt-muted", mutedColor);
+  body.style.setProperty("--bt-pill-bg", pillBg);
 
   lastThemeSample = { surface: baseSurface, dark: finalIsDark };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ import {
   formatContextListForWrite,
 } from "./core/page-refs";
 import { parseBtQuery, KNOWN_KEYS as BT_QUERY_KNOWN_KEYS } from "./core/bt-query-parser";
-import { resolvePanelIsDark } from "./core/theme-resolve.js";
+import { resolvePanelIsDark, shouldSkipThemeSync } from "./core/theme-resolve.js";
 import {
   normalizePulledSubtree,
   flattenSubtreeToCreateSteps,
@@ -19747,9 +19747,18 @@ function syncDashboardThemeVars() {
     computed.backgroundColor
   );
 
+  // Keying "nothing changed" on the surface sample alone let a genuine
+  // dark<->light transition get silently dropped: the theme-observer's
+  // class-mutation resync can land while the surface-colour heuristic still
+  // reports the pre-flip value, so the mode flip itself has to be checked
+  // too, or this returns before ever reaching the classList.toggle /
+  // six-property writes below. See shouldSkipThemeSync's header comment.
   if (
-    !btPendingRoamStudioTheme &&
-    baseSurfaceCandidate === (lastThemeSample?.surface || null)
+    shouldSkipThemeSync({
+      forced: btPendingRoamStudioTheme,
+      sameSurface: baseSurfaceCandidate === (lastThemeSample?.surface || null),
+      sameMode: (lastThemeSample?.dark ?? null) === finalIsDark,
+    })
   ) {
     return;
   }
@@ -20065,7 +20074,19 @@ async function waitForRepeatState(uid, set, options = {}, retries = 6, getBlockF
 
 function observeThemeChanges() {
   if (typeof document === "undefined") return;
-  syncDashboardThemeVars();
+
+  // Sampling immediately on boot can land mid Roam's white flash — before
+  // Roam's own theme class/background is applied — which caches a false
+  // "light" surface as lastThemeSample. shouldSkipThemeSync now re-runs on
+  // any later mode change regardless, but skipping the flash sample avoids
+  // relying on that correction at all for the common case. Defer one frame
+  // past paint; the observer below still wires up synchronously so a real
+  // theme mutation during that single frame is never missed.
+  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(() => syncDashboardThemeVars());
+  } else {
+    syncDashboardThemeVars();
+  }
 
   if (!document.body) return;
 

--- a/tests/dark-button-specificity.test.mjs
+++ b/tests/dark-button-specificity.test.mjs
@@ -1,0 +1,208 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// Roam core (assets/css/less-compiled/site.css) ships
+//     .bp3-dark button { color: var(--dark-bg); }
+// which paints EVERY <button> label with the page background colour in dark
+// mode. Any Better Tasks rule that wants to colour a <button> has to out-
+// specify it, and a plain `.bt-thing { color: ... }` at 0,1,0 does not. That
+// has now bitten three separate surfaces on this branch (Today panel row
+// titles, filter chips + task pills, analytics period chips), so this suite
+// locks the fixed surfaces in place rather than re-discovering the trap.
+const ROAM_DARK_BUTTON = ".bp3-dark button";
+
+const css = readFileSync(new URL("../extension.css", import.meta.url), "utf8");
+
+// ---------------------------------------------------------------- parsing
+
+function stripComments(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+// Minimal rule reader: walks braces so nested at-rule bodies (@media,
+// @container, @supports) are descended into rather than swallowed whole, and
+// yields { selector, declarations } for every non-at-rule block.
+function parseRules(text) {
+  const rules = [];
+  const stack = [];
+  let buffer = "";
+  for (const ch of text) {
+    if (ch === "{") {
+      const prelude = buffer.trim();
+      buffer = "";
+      stack.push(prelude.startsWith("@") ? null : prelude);
+    } else if (ch === "}") {
+      const prelude = stack.pop();
+      if (prelude) rules.push({ selector: prelude, declarations: buffer });
+      buffer = "";
+    } else {
+      buffer += ch;
+    }
+  }
+  return rules;
+}
+
+const RULES = parseRules(stripComments(css));
+
+// ------------------------------------------------------------ specificity
+
+const FUNCTIONAL_PSEUDO = /:(?:is|not|has|matches|any)\(/;
+
+// Returns [ids, classes, elements] for one compound/complex selector.
+function specificity(selector) {
+  let rest = selector.trim();
+  let ids = 0;
+  let classes = 0;
+  let elements = 0;
+
+  // :is()/:not()/:has() take the specificity of their most specific argument.
+  let match;
+  while ((match = FUNCTIONAL_PSEUDO.exec(rest))) {
+    const open = match.index + match[0].length - 1;
+    let depth = 0;
+    let close = open;
+    for (; close < rest.length; close += 1) {
+      if (rest[close] === "(") depth += 1;
+      else if (rest[close] === ")") {
+        depth -= 1;
+        if (depth === 0) break;
+      }
+    }
+    const best = rest
+      .slice(open + 1, close)
+      .split(",")
+      .map(specificity)
+      .reduce((acc, cur) => (compare(cur, acc) > 0 ? cur : acc), [0, 0, 0]);
+    ids += best[0];
+    classes += best[1];
+    elements += best[2];
+    rest = `${rest.slice(0, match.index)} ${rest.slice(close + 1)}`;
+  }
+
+  const take = (pattern, bump) => {
+    const found = rest.match(pattern) || [];
+    bump(found.length);
+    rest = rest.replace(pattern, " ");
+  };
+
+  take(/::[\w-]+/g, (n) => { elements += n; });       // pseudo-elements
+  take(/#[\w-]+/g, (n) => { ids += n; });
+  take(/\.[\w-]+/g, (n) => { classes += n; });
+  take(/\[[^\]]*\]/g, (n) => { classes += n; });
+  take(/:[\w-]+/g, (n) => { classes += n; });         // pseudo-classes
+  take(/(?:^|[\s>+~])[a-zA-Z][\w-]*/g, (n) => { elements += n; });
+
+  return [ids, classes, elements];
+}
+
+function compare(a, b) {
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+// --------------------------------------------------------------- helpers
+
+function selectorList(rule) {
+  return rule.selector.split(",").map((part) => part.trim()).filter(Boolean);
+}
+
+function declares(rule, property) {
+  return new RegExp(`(^|;)\\s*${property}\\s*:`).test(rule.declarations);
+}
+
+function isDarkScoped(selector) {
+  return /\.bp3-dark|\.bt-theme-dark/.test(selector);
+}
+
+// Every dark-scoped selector in the file that targets `target` and lives in a
+// rule declaring `property`.
+function darkSelectorsFor(target, property) {
+  const out = [];
+  for (const rule of RULES) {
+    if (!declares(rule, property)) continue;
+    for (const selector of selectorList(rule)) {
+      if (!isDarkScoped(selector)) continue;
+      if (!selector.includes(target)) continue;
+      out.push(selector);
+    }
+  }
+  return out;
+}
+
+// -------------------------------------------------------------- the tests
+
+test("the adversary rule is the specificity we think it is", () => {
+  assert.deepEqual(specificity(ROAM_DARK_BUTTON), [0, 1, 1]);
+  // A bare component class loses to it — this is the whole bug.
+  assert.ok(compare(specificity(".bt-analytics-period-btn"), specificity(ROAM_DARK_BUTTON)) < 0);
+  // And the shape used to fix it wins.
+  assert.ok(
+    compare(
+      specificity("body.bt-theme-dark .bt-analytics-period-btn"),
+      specificity(ROAM_DARK_BUTTON)
+    ) > 0
+  );
+});
+
+test("specificity() handles the selector forms this stylesheet uses", () => {
+  assert.deepEqual(specificity(":is(html, body).bp3-dark .bt-chip"), [0, 2, 1]);
+  assert.deepEqual(
+    specificity("body.bt-theme-dark .bt-analytics-period-btn:not(.bt-analytics-period-btn--active):hover"),
+    [0, 4, 1]
+  );
+  assert.deepEqual(specificity("body.bt-theme-dark .bt-analytics-header .bp3-button"), [0, 3, 1]);
+});
+
+// Each of these renders as a <button> and therefore needs an explicit dark
+// colour that beats `.bp3-dark button`.
+const BUTTON_SURFACES = [
+  ".bt-analytics-period-btn",
+  ".bt-analytics-period-btn--active",
+  ".bt-chip",
+  ".bt-chip--active",
+  ".bt-pill",
+  ".bt-today-panel-root button",
+];
+
+for (const target of BUTTON_SURFACES) {
+  test(`${target} has a dark colour rule that outranks .bp3-dark button`, () => {
+    const selectors = darkSelectorsFor(target, "color");
+    assert.ok(selectors.length > 0, `no dark-scoped colour rule found for ${target}`);
+    for (const selector of selectors) {
+      assert.ok(
+        compare(specificity(selector), specificity(ROAM_DARK_BUTTON)) > 0,
+        `${selector} is ${specificity(selector).join(",")} — does not beat ${ROAM_DARK_BUTTON}`
+      );
+    }
+  });
+}
+
+// bp3-dark lives on <html> in this Roam build, so a rule that only ever says
+// `body.bp3-dark` never fires; each of these needs the :is(html, body) form or
+// the JS-applied bt-theme-dark class to reach it.
+for (const target of BUTTON_SURFACES) {
+  test(`${target} is reachable when bp3-dark sits on <html>`, () => {
+    const selectors = darkSelectorsFor(target, "color");
+    assert.ok(
+      selectors.some((s) => /:is\(\s*html\s*,\s*body\s*\)\.bp3-dark|\.bt-theme-dark/.test(s)),
+      `${target} is only covered by \`body.bp3-dark\`, which never matches`
+    );
+  });
+}
+
+test("the analytics close button is covered beyond Blueprint's own dark rule", () => {
+  const selectors = darkSelectorsFor(".bt-analytics-header .bp3-button", "color");
+  assert.ok(selectors.length > 0, "no dark rule for the analytics header close button");
+  // Blueprint ships `.bp3-dark .bp3-button` at 0,2,0; ours has to beat that too.
+  for (const selector of selectors) {
+    assert.ok(compare(specificity(selector), [0, 2, 0]) > 0, `${selector} does not beat .bp3-dark .bp3-button`);
+  }
+});
+
+test("the analytics panel keeps a dark backdrop like the other overlays", () => {
+  const selectors = darkSelectorsFor(".bt-analytics-overlay__backdrop", "background");
+  assert.ok(selectors.length > 0, "analytics overlay has no dark backdrop rule");
+});

--- a/tests/theme-resolve.test.mjs
+++ b/tests/theme-resolve.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolvePanelIsDark } from "../src/core/theme-resolve.js";
+import { resolvePanelIsDark, shouldSkipThemeSync } from "../src/core/theme-resolve.js";
 
 // Regression: macOS in dark mode, Roam in its default light theme, no theme
 // extension toggle mounted. The OS hint used to win and mark the body
@@ -118,4 +118,43 @@ test("NaN luminance is treated as no sample", () => {
     }),
     true
   );
+});
+
+// Regression: a theme-observer class-mutation resync landed with the
+// surface-colour heuristic still reporting the pre-flip value even though
+// the resolved mode had genuinely changed (dark just activated). Keying the
+// skip decision on surface alone made syncDashboardThemeVars return before
+// ever reaching classList.toggle("bt-theme-dark", ...) or the six
+// custom-property writes, so the panel stayed stuck light while
+// bt-theme-dark read true from a stale prior write.
+test("shouldSkipThemeSync: skips only when both surface and mode are unchanged", () => {
+  assert.equal(
+    shouldSkipThemeSync({ forced: false, sameSurface: true, sameMode: true }),
+    true
+  );
+});
+
+test("shouldSkipThemeSync: a mode change always proceeds, even with a same-looking surface sample", () => {
+  assert.equal(
+    shouldSkipThemeSync({ forced: false, sameSurface: true, sameMode: false }),
+    false
+  );
+});
+
+test("shouldSkipThemeSync: a surface change always proceeds, even with the same resolved mode", () => {
+  assert.equal(
+    shouldSkipThemeSync({ forced: false, sameSurface: false, sameMode: true }),
+    false
+  );
+});
+
+test("shouldSkipThemeSync: a forced resync (pending toggle click) always proceeds", () => {
+  assert.equal(
+    shouldSkipThemeSync({ forced: true, sameSurface: true, sameMode: true }),
+    false
+  );
+});
+
+test("shouldSkipThemeSync: defaults to not skipping when called with no arguments", () => {
+  assert.equal(shouldSkipThemeSync(), false);
 });

--- a/tests/theme-resolve.test.mjs
+++ b/tests/theme-resolve.test.mjs
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolvePanelIsDark } from "../src/core/theme-resolve.js";
+
+// Regression: macOS in dark mode, Roam in its default light theme, no theme
+// extension toggle mounted. The OS hint used to win and mark the body
+// bt-theme-dark, painting the Today panel's pinned near-white text onto the
+// white page. The sampled background (white, luminance 1.0) must win instead.
+test("OS dark + Roam light background resolves light", () => {
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: null,
+      explicitDark: false,
+      sampledLuminance: 1.0,
+      systemPrefersDark: true,
+    }),
+    false
+  );
+});
+
+test("dark background resolves dark even when the OS is light", () => {
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: null,
+      explicitDark: false,
+      sampledLuminance: 0.02,
+      systemPrefersDark: false,
+    }),
+    true
+  );
+});
+
+test("toggle set to light overrides everything", () => {
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: "light",
+      explicitDark: true,
+      sampledLuminance: 0.02,
+      systemPrefersDark: true,
+    }),
+    false
+  );
+});
+
+test("toggle set to dark overrides everything", () => {
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: "dark",
+      explicitDark: false,
+      sampledLuminance: 1.0,
+      systemPrefersDark: false,
+    }),
+    true
+  );
+});
+
+test("bp3-dark marker beats a light sample taken mid theme load", () => {
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: null,
+      explicitDark: true,
+      sampledLuminance: 1.0,
+      systemPrefersDark: false,
+    }),
+    true
+  );
+});
+
+test("toggle in auto mode defers to the sampled background", () => {
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: "auto",
+      explicitDark: false,
+      sampledLuminance: 1.0,
+      systemPrefersDark: true,
+    }),
+    false
+  );
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: "auto",
+      explicitDark: false,
+      sampledLuminance: 0.02,
+      systemPrefersDark: false,
+    }),
+    true
+  );
+});
+
+test("no sample available falls back to the OS hint", () => {
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: null,
+      explicitDark: false,
+      sampledLuminance: null,
+      systemPrefersDark: true,
+    }),
+    true
+  );
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: null,
+      explicitDark: false,
+      sampledLuminance: null,
+      systemPrefersDark: false,
+    }),
+    false
+  );
+});
+
+test("NaN luminance is treated as no sample", () => {
+  assert.equal(
+    resolvePanelIsDark({
+      externalMode: null,
+      explicitDark: false,
+      sampledLuminance: NaN,
+      systemPrefersDark: true,
+    }),
+    true
+  );
+});


### PR DESCRIPTION
In dark mode the Today panel looks empty: task titles render dark-on-dark and the icon buttons show up as ghost outlines.

`.bt-today-panel__row-title` uses `color: inherit`, and the icon buttons read `--bt-panel-text`. Both can resolve to a light-theme value under Roam's dark theme, because `--bp3-text-color` stays at `#202B33` under `.bp3-dark`. The panel pins literal light values instead of routing through the sampled variable, matching what the task-row dark rules above it already do.

This PR is CSS only — `extension.css`, no JavaScript, no build output.

## Covered

The first commit fixes the reported symptom: panel root colour and the icon buttons' background/colour/border.

The second commit closes the states the first one left behind, all of which are part of the same panel:

- **Disabled buttons.** `disableAll()` marks the action buttons disabled while a complete/snooze is in flight. Pinning `color` at author level beats the user-agent `button:disabled` grey, so the first commit removed the only disabled feedback there was. They now get their own dimmer background/colour/border plus `cursor: not-allowed` — explicit values rather than `opacity`, which would multiply against the already-alpha'd text and land back in a low-contrast state.
- **Hover.** There was no `:hover` rule for these buttons in any theme; dark now brightens background and border rather than leaving hover indistinguishable.
- **Sidebar badge.** `.bt-today-badge:hover` used `rgba(0,0,0,0.06)`, so it *darkened* against a dark panel, and `.bt-today-badge__icon` was a fixed mid-tone. Both now have dark variants.
- **Focus ring.** The shared `:focus-visible` outline is `#2b6cb0`, a dark navy against a dark panel. Overridden to `#63b3ed` for this panel's buttons only — roughly 6.9:1 against the panel surface, versus the 3:1 WCAG threshold for non-text. The shared rule also covers task-menu and bulk-action buttons, which are outside this PR's scope, so those are untouched.

## Third commit — the row titles were still invisible

**Correcting an inaccurate claim in the two commits above.** They described the panel-root colour as something "the row titles, section headers and empty state all inherit". That is true for the section headers and the empty state, but **not** for the row titles, and the panel remained broken in exactly the way this PR set out to fix. The earlier live-verification covered the icon buttons' enabled/hover/disabled/focus states and did not check a row title.

Root cause, from `CSS.getMatchedStylesForNode` on a live node:

| rule | specificity | colour | origin |
|---|---|---|---|
| `button, input, optgroup, select, textarea` | 0,0,1 | `inherit` | user agent |
| `.bt-today-panel__row-title` | 0,1,0 | `inherit` | this extension |
| **`.bp3-dark button`** | **0,1,1** | **`var(--dark-bg)`** | **Roam core, `assets/css/less-compiled/site.css`** |

Roam core paints *every* `<button>` under `.bp3-dark` with the theme's **background** colour. `.bt-today-panel__row-title` is a bare transparent `<button>` relying on `color: inherit`, so Roam's 0,1,1 beats the extension's 0,1,0 and the title is drawn in the panel background colour. Measured on a live graph: computed `rgb(32,43,51)` on a `rgb(32,43,51)` background — **contrast ratio 1.00**.

The icon buttons were never affected because their dark rule is 0,2,0, which is why the panel looked fixed while the titles stayed unreadable.

The fix scopes the rule to the panel root and matches `button` directly (0,2,2), so any button added to this panel later is covered rather than silently disappearing; the disabled-state rule remains 0,3,0 and still wins.

It also does not rely on `body.bp3-dark` alone. In current Roam builds `bp3-dark` sits on `<html>`, not `<body>` — a live DOM read shows `body.className === "rm-electron bt-theme-dark"` — so every `body.bp3-dark …` selector in this file matches nothing and only the `body.bt-theme-dark` half is load-bearing. Hence the `:is(html, body).bp3-dark` form plus a `prefers-color-scheme` fallback for auto mode, where `.bp3-dark` is absent entirely.

Verified live on an encrypted graph, injecting the rule and reading computed styles:

| | colour | contrast vs panel |
|---|---|---|
| before | `rgb(32,43,51)` | **1.00** |
| after | `rgba(247,249,251,0.92)` | **13.68** |

Icon buttons unchanged at 13.68; no `bt-*` node in the panel measures below 3:1 afterwards. The probe element was removed and the DOM restored before/after the check.

## Deliberately not changed

Blocked and completed rows carry `opacity: 0.55` / `0.6`, which composites the panel's `rgba(247,249,251,0.92)` text down to roughly 0.51–0.55 effective alpha. Measured against both plausible dark panel surfaces that is 4.65:1 and 4.86:1 — above the 4.5:1 AA threshold for normal text, so dimmed but not illegible. Changing it would mean touching the row-opacity logic in `src/index.js`, which is beyond a CSS legibility fix.

The `--due` / `--overdue` modifier classes the panel adds have no CSS behind them in any theme. That is a pre-existing gap, not a dark-mode one, so it is left alone here.

The dead `body.bp3-dark …` selectors elsewhere in this file are left in place: removing them is a wider cleanup than this fix, and they are inert rather than harmful.

## Checks

- strict i18n parity passed
- 250/250 tests pass
- no selector added here matches a native Roam container; the existing `.rm-block*` rules stay scoped under `.bt-today-panel-block` / `.bt-today-panel-inline-hidden`
- computed styles verified live in Roam under both `bp3-dark` and `bt-theme-dark` for enabled, hover, disabled and focus states — and, as of the third commit, for the row titles that the earlier verification missed

## Note on ordering

This branch is based directly on `main` and touches only `extension.css`, so it is independent of #14 and the two merge cleanly in either order (verified with `git merge-tree`).


## Update (2026-08-06): light-mode regression fixed in this branch

Live use surfaced the inverse bug: on a dark-mode OS with Roam in its default light theme (no theme extension, no `bp3-dark`), `syncDashboardThemeVars` fell through to `prefers-color-scheme`, tagged `body.bt-theme-dark`, and the panel's pinned near-white dark-mode text painted onto the white page — washed-out, near-invisible rows in light mode.

The fourth commit (`10c2241`) fixes the resolution order in `src/index.js`: theme-toggle (light/dark) > `bp3-dark` marker > **measured luminance of Roam's rendered background** > OS `prefers-color-scheme` (last-resort only, e.g. before Roam's chrome mounts). The decision is extracted as a pure `resolvePanelIsDark` in `src/core/theme-resolve.js` with unit tests covering the full matrix (258/258 pass). This makes the branch no longer CSS-only; the "touches only `extension.css`" note above predates this commit, though it remains independent of #14 and still merges cleanly in either order.

A follow-up commit (`5cc9589`) hardens the luminance sampling: Roam paints the page background on `<body>` while `.roam-main` and everything between it and the article is transparent, so the selector-level sample returned null and the decision still fell through to the OS hint. The sampler now walks each candidate's ancestor chain until it finds a painted element (verified live against the desktop client, where `<body>` carries the colour).
